### PR TITLE
Fix/link dependency

### DIFF
--- a/apps/example/src/components/AppBar.tsx
+++ b/apps/example/src/components/AppBar.tsx
@@ -53,6 +53,12 @@ export function AppBar({ context, actions }: AppBarProps) {
         >
           Docs
         </Link>
+        <Link
+          href="/playground"
+          className="rounded-md px-2.5 py-1.5 text-sm font-medium text-zinc-900 hover:bg-zinc-100"
+        >
+          Playground
+        </Link>
         <a
           href={REPO_URL}
           target="_blank"

--- a/apps/example/src/data/playground-presets.ts
+++ b/apps/example/src/data/playground-presets.ts
@@ -1,0 +1,423 @@
+/**
+ * Sandpack presets for the playground. Each preset is a self-contained
+ * React snippet whose `dependencies` map references `@crudx/*` from
+ * npm — so when the user opens the playground, Sandpack fetches the
+ * actually-published artifacts. This is what makes the playground a
+ * smoke test for the released libs (not just the workspace source).
+ */
+
+export type UiKind = 'mui' | 'shadcn';
+export type DemoKind = 'component' | 'crud';
+
+export type PresetSlug =
+  | 'mui-table'
+  | 'shadcn-table'
+  | 'mui-crud'
+  | 'shadcn-crud';
+
+export type Preset = {
+  slug: PresetSlug;
+  title: string;
+  description: string;
+  ui: UiKind;
+  kind: DemoKind;
+  /** File map handed to Sandpack. `/App.tsx` is the entry. */
+  files: Record<string, string>;
+  /** Runtime deps installed from npm by Sandpack. */
+  dependencies: Record<string, string>;
+};
+
+const CRUDX_VERSION = '^1.0.0';
+
+/**
+ * Inline `<style>` block holding the shadcn theme variables. Pasted
+ * straight into the Sandpack `index.html` for the shadcn presets. We
+ * also load Tailwind via the Play CDN so the classnames the lib emits
+ * actually render — Tailwind normally runs on the consumer side.
+ */
+const SHADCN_TAILWIND_HTML = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Crudx playground</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+      @layer base {
+        :root {
+          --background: 0 0% 100%;
+          --foreground: 222.2 47.4% 11.2%;
+          --muted: 210 40% 96.1%;
+          --muted-foreground: 215.4 16.3% 46.9%;
+          --popover: 0 0% 100%;
+          --popover-foreground: 222.2 47.4% 11.2%;
+          --card: 0 0% 100%;
+          --card-foreground: 222.2 47.4% 11.2%;
+          --border: 214.3 31.8% 91.4%;
+          --input: 214.3 31.8% 91.4%;
+          --primary: 222.2 47.4% 11.2%;
+          --primary-foreground: 210 40% 98%;
+          --secondary: 210 40% 96.1%;
+          --secondary-foreground: 222.2 47.4% 11.2%;
+          --accent: 210 40% 96.1%;
+          --accent-foreground: 222.2 47.4% 11.2%;
+          --destructive: 0 100% 50%;
+          --destructive-foreground: 210 40% 98%;
+          --ring: 215 20.2% 65.1%;
+          --radius: 0.5rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>
+`;
+
+const MUI_INDEX_TSX = `import { createRoot } from 'react-dom/client';
+import App from './App';
+
+createRoot(document.getElementById('root')!).render(<App />);
+`;
+
+const SHADCN_INDEX_TSX = MUI_INDEX_TSX;
+
+const MUI_TABLE_APP = `import { useState } from 'react';
+import { Table } from '@crudx/mui';
+
+type Row = { id: number; name: string; role: string };
+
+const data: Row[] = [
+  { id: 1, name: 'Alice',   role: 'Admin'  },
+  { id: 2, name: 'Bob',     role: 'Editor' },
+  { id: 3, name: 'Carol',   role: 'Viewer' },
+  { id: 4, name: 'David',   role: 'Editor' },
+  { id: 5, name: 'Eve',     role: 'Admin'  },
+];
+
+export default function App() {
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(5);
+
+  return (
+    <div style={{ padding: 24 }}>
+      <h2 style={{ marginBottom: 12 }}>@crudx/mui · Table</h2>
+      <Table
+        data={data}
+        columns={[
+          { key: 'id',   title: 'ID',   dataIndex: 'id',   width: 80, sortable: true },
+          { key: 'name', title: 'Name', dataIndex: 'name' },
+          { key: 'role', title: 'Role', dataIndex: 'role' },
+        ]}
+        page={page}
+        pageSize={pageSize}
+        total={data.length}
+        onPageChange={setPage}
+        onPageSizeChange={setPageSize}
+      />
+    </div>
+  );
+}
+`;
+
+const SHADCN_TABLE_APP = `import { useState } from 'react';
+import { Table } from '@crudx/shadcn';
+
+type Row = { id: number; name: string; role: string };
+
+const data: Row[] = [
+  { id: 1, name: 'Alice',   role: 'Admin'  },
+  { id: 2, name: 'Bob',     role: 'Editor' },
+  { id: 3, name: 'Carol',   role: 'Viewer' },
+  { id: 4, name: 'David',   role: 'Editor' },
+  { id: 5, name: 'Eve',     role: 'Admin'  },
+];
+
+export default function App() {
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(5);
+
+  return (
+    <div className="p-6">
+      <h2 className="mb-3 text-xl font-semibold">@crudx/shadcn · Table</h2>
+      <Table
+        data={data}
+        columns={[
+          { key: 'id',   title: 'ID',   dataIndex: 'id',   width: 80, sortable: true },
+          { key: 'name', title: 'Name', dataIndex: 'name' },
+          { key: 'role', title: 'Role', dataIndex: 'role' },
+        ]}
+        page={page}
+        pageSize={pageSize}
+        total={data.length}
+        onPageChange={setPage}
+        onPageSizeChange={setPageSize}
+      />
+    </div>
+  );
+}
+`;
+
+const CRUD_REST_HOOK = `import { useMemo } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createRestTanstackAdapter } from '@crudx/rest-tanstack-adapter';
+
+type Post = { id: number; title: string; body: string };
+
+type PostSchemata = {
+  list:   [{ data: Post[]; total: number }, { _page?: number; _limit?: number }, Post];
+  get:    [Post, { id: number }, Post];
+  create: [Post, { title: string; body: string }];
+  update: [Post, { id: number; title?: string; body?: string }];
+  delete: [{ id: number }, { id: number }];
+};
+
+const BASE = 'https://jsonplaceholder.typicode.com';
+const rest = createRestTanstackAdapter();
+
+export const postsSchema = rest.schema<PostSchemata>({
+  list: {
+    key: 'posts',
+    resource: 'posts',
+    fetch: async ({ variables, signal }) => {
+      const params = new URLSearchParams();
+      if (variables._page)  params.set('_page',  String(variables._page));
+      if (variables._limit) params.set('_limit', String(variables._limit));
+      const res = await fetch(\`\${BASE}/posts?\${params}\`, { signal });
+      const data = await res.json();
+      const total = Number(res.headers.get('x-total-count') ?? data.length);
+      return { data, total };
+    },
+  },
+  get: {
+    key: 'post',
+    resource: ['posts', 'detail'],
+    fetch: async ({ variables, signal }) => {
+      const res = await fetch(\`\${BASE}/posts/\${variables.id}\`, { signal });
+      return res.json();
+    },
+  },
+  create: {
+    key: 'post',
+    resource: ['posts', 'create'],
+    invalidates: 'posts',
+    request: async ({ variables }) => {
+      const res = await fetch(\`\${BASE}/posts\`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId: 1, ...variables }),
+      });
+      return res.json();
+    },
+  },
+  update: {
+    key: 'post',
+    resource: ['posts', 'update'],
+    invalidates: 'posts',
+    request: async ({ variables }) => {
+      const { id, ...body } = variables;
+      const res = await fetch(\`\${BASE}/posts/\${id}\`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      return res.json();
+    },
+  },
+  delete: {
+    key: 'post',
+    resource: ['posts', 'delete'],
+    invalidates: 'posts',
+    request: async ({ variables }) => {
+      await fetch(\`\${BASE}/posts/\${variables.id}\`, { method: 'DELETE' });
+      return { id: variables.id };
+    },
+  },
+});
+
+export type { PostSchemata };
+export { rest };
+
+export function withQuery(Inner: React.ComponentType) {
+  return function Wrapped() {
+    const qc = useMemo(() => new QueryClient({ defaultOptions: { queries: { refetchOnWindowFocus: false } } }), []);
+    return (
+      <QueryClientProvider client={qc}>
+        <Inner />
+      </QueryClientProvider>
+    );
+  };
+}
+`;
+
+const MUI_CRUD_APP = `import { CrudPanelView } from '@crudx/mui';
+import { postsSchema, rest, withQuery, PostSchemata } from './crud';
+
+function PostsPanel() {
+  return (
+    <CrudPanelView<PostSchemata>
+      name="post"
+      schema={postsSchema}
+      pageTitle="Posts"
+      columnDataIndex="id"
+      columns={[
+        { key: 'id',    title: 'ID',    width: 80,  dataIndex: 'id'    },
+        { key: 'title', title: 'Title', width: 280, dataIndex: 'title' },
+        { key: 'body',  title: 'Body',  dataIndex: 'body' },
+      ]}
+      tableActions={[{ action: 'refresh' }]}
+      paging={{
+        strategy: 'CUSTOM',
+        pageSize: 5,
+        custom: rest.offsetPagination({ pageKey: '_page', pageSizeKey: '_limit' }),
+      }}
+    />
+  );
+}
+
+export default withQuery(PostsPanel);
+`;
+
+const SHADCN_CRUD_APP = `import { CrudPanelView } from '@crudx/shadcn';
+import { postsSchema, rest, withQuery, PostSchemata } from './crud';
+
+function PostsPanel() {
+  return (
+    <CrudPanelView<PostSchemata>
+      name="post"
+      schema={postsSchema}
+      pageTitle="Posts"
+      columnDataIndex="id"
+      columns={[
+        { key: 'id',    title: 'ID',    width: 80,  dataIndex: 'id'    },
+        { key: 'title', title: 'Title', width: 280, dataIndex: 'title' },
+        { key: 'body',  title: 'Body',  dataIndex: 'body' },
+      ]}
+      tableActions={[{ action: 'refresh' }]}
+      paging={{
+        strategy: 'CUSTOM',
+        pageSize: 5,
+        custom: rest.offsetPagination({ pageKey: '_page', pageSizeKey: '_limit' }),
+      }}
+    />
+  );
+}
+
+export default withQuery(PostsPanel);
+`;
+
+const MUI_TABLE_DEPS = {
+  '@crudx/common': CRUDX_VERSION,
+  '@crudx/core': CRUDX_VERSION,
+  '@crudx/mui': CRUDX_VERSION,
+  '@mui/material': '^5.14.0',
+  '@mui/icons-material': '^5.14.0',
+  '@emotion/react': '^11.11.0',
+  '@emotion/styled': '^11.11.0',
+  classnames: '^2.3.0',
+  lodash: '^4.17.0',
+  'react-hot-toast': '^2.4.0',
+};
+
+const SHADCN_TABLE_DEPS = {
+  '@crudx/common': CRUDX_VERSION,
+  '@crudx/core': CRUDX_VERSION,
+  '@crudx/shadcn': CRUDX_VERSION,
+  '@tanstack/react-table': '^8.11.0',
+  '@radix-ui/react-checkbox': '^1.0.4',
+  '@radix-ui/react-collapsible': '^1.0.3',
+  '@radix-ui/react-dialog': '^1.0.5',
+  '@radix-ui/react-dropdown-menu': '^2.0.6',
+  '@radix-ui/react-label': '^2.0.2',
+  '@radix-ui/react-popover': '^1.0.7',
+  '@radix-ui/react-select': '^2.0.0',
+  '@radix-ui/react-separator': '^1.0.3',
+  '@radix-ui/react-slot': '^1.0.2',
+  '@radix-ui/react-tabs': '^1.0.4',
+  '@radix-ui/react-tooltip': '^1.0.7',
+  'class-variance-authority': '^0.7.0',
+  classnames: '^2.3.0',
+  clsx: '^2.0.0',
+  'lucide-react': '^0.294.0',
+  'react-hot-toast': '^2.4.0',
+  'tailwind-merge': '^2.1.0',
+};
+
+const MUI_CRUD_DEPS = {
+  ...MUI_TABLE_DEPS,
+  '@crudx/rest-tanstack-adapter': CRUDX_VERSION,
+  '@tanstack/react-query': '^4.36.0',
+};
+
+const SHADCN_CRUD_DEPS = {
+  ...SHADCN_TABLE_DEPS,
+  '@crudx/rest-tanstack-adapter': CRUDX_VERSION,
+  '@tanstack/react-query': '^4.36.0',
+};
+
+export const PRESETS: Record<PresetSlug, Preset> = {
+  'mui-table': {
+    slug: 'mui-table',
+    title: 'MUI · Table',
+    description:
+      'Standalone Table component from @crudx/mui with hard-coded rows + pagination. Smallest possible smoke test for the published MUI bundle.',
+    ui: 'mui',
+    kind: 'component',
+    files: {
+      '/index.tsx': MUI_INDEX_TSX,
+      '/App.tsx': MUI_TABLE_APP,
+    },
+    dependencies: MUI_TABLE_DEPS,
+  },
+  'shadcn-table': {
+    slug: 'shadcn-table',
+    title: 'shadcn · Table',
+    description:
+      'Standalone Table component from @crudx/shadcn. Tailwind via the Play CDN, shadcn theme variables inlined into index.html.',
+    ui: 'shadcn',
+    kind: 'component',
+    files: {
+      '/public/index.html': SHADCN_TAILWIND_HTML,
+      '/index.tsx': SHADCN_INDEX_TSX,
+      '/App.tsx': SHADCN_TABLE_APP,
+    },
+    dependencies: SHADCN_TABLE_DEPS,
+  },
+  'mui-crud': {
+    slug: 'mui-crud',
+    title: 'MUI · CrudPanelView',
+    description:
+      'Full CrudPanelView wired through @crudx/rest-tanstack-adapter against JSONPlaceholder. Exercises the cross-package surface in one snippet.',
+    ui: 'mui',
+    kind: 'crud',
+    files: {
+      '/index.tsx': MUI_INDEX_TSX,
+      '/crud.tsx': CRUD_REST_HOOK,
+      '/App.tsx': MUI_CRUD_APP,
+    },
+    dependencies: MUI_CRUD_DEPS,
+  },
+  'shadcn-crud': {
+    slug: 'shadcn-crud',
+    title: 'shadcn · CrudPanelView',
+    description:
+      'Same JSONPlaceholder CRUD flow rendered through @crudx/shadcn. Drop-in alternative to the MUI variant; same prop surface.',
+    ui: 'shadcn',
+    kind: 'crud',
+    files: {
+      '/public/index.html': SHADCN_TAILWIND_HTML,
+      '/index.tsx': SHADCN_INDEX_TSX,
+      '/crud.tsx': CRUD_REST_HOOK,
+      '/App.tsx': SHADCN_CRUD_APP,
+    },
+    dependencies: SHADCN_CRUD_DEPS,
+  },
+};
+
+export const PRESET_ORDER: PresetSlug[] = [
+  'mui-table',
+  'shadcn-table',
+  'mui-crud',
+  'shadcn-crud',
+];

--- a/apps/example/src/pages/_app.tsx
+++ b/apps/example/src/pages/_app.tsx
@@ -1,4 +1,6 @@
+import { LinkProvider } from '@crudx/common';
 import Head from 'next/head';
+import NextLink from 'next/link';
 
 import 'animate.css';
 import 'react-perfect-scrollbar/dist/css/styles.css';
@@ -8,7 +10,7 @@ const MyApp = (props) => {
   const { Component, pageProps } = props;
 
   return (
-    <>
+    <LinkProvider Link={NextLink as any}>
       <Head>
         <meta
           name="viewport"
@@ -17,7 +19,7 @@ const MyApp = (props) => {
         <title>Crudx Example</title>
       </Head>
       <Component {...pageProps} />
-    </>
+    </LinkProvider>
   );
 };
 

--- a/apps/example/src/pages/docs/[slug].tsx
+++ b/apps/example/src/pages/docs/[slug].tsx
@@ -207,8 +207,8 @@ export const getStaticPaths: GetStaticPaths = async () => ({
 });
 
 export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
-  const slug = params!.slug as DocSlug;
-  const meta = DOCS[slug];
+  const slug = params?.slug as DocSlug | undefined;
+  const meta = slug ? DOCS[slug] : undefined;
   if (!meta) return { notFound: true };
   return { props: { meta } };
 };

--- a/apps/example/src/pages/playground/[slug].tsx
+++ b/apps/example/src/pages/playground/[slug].tsx
@@ -5,17 +5,13 @@
  * published artifacts.
  */
 
-import dynamic from 'next/dynamic';
-import { GetStaticPaths, GetStaticProps } from 'next';
 import { ArrowLeft } from 'lucide-react';
+import { GetStaticPaths, GetStaticProps } from 'next';
+import dynamic from 'next/dynamic';
 import Link from 'next/link';
 
 import { AppBar } from '../../components';
-import {
-  PRESETS,
-  Preset,
-  PresetSlug,
-} from '../../data/playground-presets';
+import { Preset, PRESETS, PresetSlug } from '../../data/playground-presets';
 
 // Sandpack ships its own Monaco-style editor and pulls in a fair bit
 // of code; load it client-side only so it doesn't bloat the initial
@@ -70,8 +66,8 @@ export const getStaticPaths: GetStaticPaths = async () => ({
 });
 
 export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
-  const slug = params!.slug as PresetSlug;
-  const preset = PRESETS[slug];
+  const slug = params?.slug as PresetSlug | undefined;
+  const preset = slug ? PRESETS[slug] : undefined;
   if (!preset) return { notFound: true };
   return { props: { preset } };
 };

--- a/apps/example/src/pages/playground/[slug].tsx
+++ b/apps/example/src/pages/playground/[slug].tsx
@@ -1,0 +1,77 @@
+/**
+ * Sandpack-hosted playground for a single preset. The `@crudx/*` deps
+ * come from npm, so what runs in the iframe is whatever the registry
+ * currently serves — the playground doubles as a smoke test for the
+ * published artifacts.
+ */
+
+import dynamic from 'next/dynamic';
+import { GetStaticPaths, GetStaticProps } from 'next';
+import { ArrowLeft } from 'lucide-react';
+import Link from 'next/link';
+
+import { AppBar } from '../../components';
+import {
+  PRESETS,
+  Preset,
+  PresetSlug,
+} from '../../data/playground-presets';
+
+// Sandpack ships its own Monaco-style editor and pulls in a fair bit
+// of code; load it client-side only so it doesn't bloat the initial
+// HTML payload of the static export.
+const Sandpack = dynamic(
+  () => import('@codesandbox/sandpack-react').then((m) => m.Sandpack),
+  { ssr: false }
+);
+
+type Props = { preset: Preset };
+
+export default function PlaygroundSlugPage({ preset }: Props) {
+  return (
+    <div className="min-h-screen bg-white text-zinc-900">
+      <AppBar context="Playground" />
+      <main className="mx-auto max-w-screen-2xl px-4 py-6">
+        <Link
+          href="/playground"
+          className="inline-flex items-center gap-1 text-sm text-zinc-600 hover:text-zinc-900"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          All playgrounds
+        </Link>
+
+        <header className="mt-3 mb-5">
+          <h1 className="text-2xl font-bold tracking-tight">{preset.title}</h1>
+          <p className="mt-1 text-sm text-zinc-600">{preset.description}</p>
+        </header>
+
+        <Sandpack
+          template="react-ts"
+          theme="light"
+          files={preset.files}
+          customSetup={{ dependencies: preset.dependencies }}
+          options={{
+            showTabs: true,
+            showLineNumbers: true,
+            showInlineErrors: true,
+            wrapContent: true,
+            editorHeight: 640,
+            editorWidthPercentage: 50,
+          }}
+        />
+      </main>
+    </div>
+  );
+}
+
+export const getStaticPaths: GetStaticPaths = async () => ({
+  paths: Object.keys(PRESETS).map((slug) => ({ params: { slug } })),
+  fallback: false,
+});
+
+export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
+  const slug = params!.slug as PresetSlug;
+  const preset = PRESETS[slug];
+  if (!preset) return { notFound: true };
+  return { props: { preset } };
+};

--- a/apps/example/src/pages/playground/index.tsx
+++ b/apps/example/src/pages/playground/index.tsx
@@ -1,0 +1,107 @@
+/**
+ * Playground landing. Lists every Sandpack preset that lives under
+ * /playground/[slug] — each one fetches `@crudx/*` from npm so the
+ * preview validates the actually-published artifact, not the workspace
+ * source.
+ */
+
+import { ArrowRight, Layers, Network, PlayCircle, Server } from 'lucide-react';
+import Link from 'next/link';
+
+import { AppBar } from '../../components';
+import {
+  DemoKind,
+  PRESETS,
+  PRESET_ORDER,
+  PresetSlug,
+  UiKind,
+} from '../../data/playground-presets';
+
+const KIND_LABEL: Record<DemoKind, string> = {
+  component: 'Component',
+  crud: 'CRUD',
+};
+
+const UI_BADGE: Record<UiKind, { label: string; color: string }> = {
+  mui: { label: 'MUI', color: '#1976D2' },
+  shadcn: { label: 'shadcn', color: '#18181B' },
+};
+
+const ICONS: Record<PresetSlug, JSX.Element> = {
+  'mui-table': <Layers className="h-5 w-5" />,
+  'shadcn-table': <Layers className="h-5 w-5" />,
+  'mui-crud': <Network className="h-5 w-5" />,
+  'shadcn-crud': <Server className="h-5 w-5" />,
+};
+
+export default function PlaygroundIndexPage() {
+  return (
+    <div className="min-h-screen bg-white text-zinc-900">
+      <AppBar context="Playground" />
+      <main className="mx-auto max-w-screen-md px-4 py-10">
+        <header className="mb-8">
+          <div className="mb-2 inline-flex items-center gap-2 rounded-full bg-emerald-50 px-3 py-1 text-xs font-medium text-emerald-700">
+            <PlayCircle className="h-3.5 w-3.5" />
+            Live preview · published npm packages
+          </div>
+          <h1 className="text-3xl font-bold tracking-tight">Playground</h1>
+          <p className="mt-2 text-zinc-600">
+            Each preset boots a Sandpack sandbox that installs{' '}
+            <code className="rounded bg-zinc-100 px-1.5 py-0.5 text-sm">@crudx/*</code>{' '}
+            from npm — so you're exercising the actually-published bundle, not
+            the workspace source. Edit the code on the left, see the rendered
+            output on the right.
+          </p>
+        </header>
+
+        <ul className="grid gap-3 sm:grid-cols-2">
+          {PRESET_ORDER.map((slug) => {
+            const meta = PRESETS[slug];
+            const ui = UI_BADGE[meta.ui];
+            return (
+              <li key={slug}>
+                <Link
+                  href={`/playground/${slug}`}
+                  className="group flex h-full flex-col gap-3 rounded-xl border border-zinc-200 p-5 transition hover:border-zinc-400 hover:bg-zinc-50"
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="grid h-9 w-9 place-items-center rounded-lg bg-zinc-900 text-white">
+                      {ICONS[slug]}
+                    </span>
+                    <span className="flex items-center gap-2 text-xs font-medium">
+                      <span
+                        className="rounded-full px-2 py-0.5 text-white"
+                        style={{ backgroundColor: ui.color }}
+                      >
+                        {ui.label}
+                      </span>
+                      <span className="rounded-full border border-zinc-200 px-2 py-0.5 text-zinc-600">
+                        {KIND_LABEL[meta.kind]}
+                      </span>
+                    </span>
+                  </div>
+                  <span className="flex items-center gap-2">
+                    <span className="text-base font-semibold">
+                      {meta.title}
+                    </span>
+                    <ArrowRight className="h-4 w-4 opacity-0 transition group-hover:translate-x-0.5 group-hover:opacity-100" />
+                  </span>
+                  <span className="text-sm text-zinc-600">
+                    {meta.description}
+                  </span>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+
+        <p className="mt-8 text-xs text-zinc-500">
+          Sandpack pulls dependencies from the public npm registry. If a
+          preset fails to load, double-check that the matching{' '}
+          <code className="rounded bg-zinc-100 px-1 py-0.5">@crudx/*</code>{' '}
+          version has actually been published.
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/libs/common/src/components/LinkProvider/index.tsx
+++ b/libs/common/src/components/LinkProvider/index.tsx
@@ -1,0 +1,91 @@
+/**
+ * ===========================
+ * LinkProvider
+ * ===========================
+ *
+ * Lets the consumer plug in their preferred client-side `Link` component
+ * (Next.js, React Router, TanStack Router, …) without the `@crudx/*`
+ * libs taking a hard dependency on any specific framework.
+ *
+ * The default renders a plain `<a>`, which works in any React app —
+ * consumers who want SPA navigation wrap their app in `<LinkProvider
+ * Link={MyLink} />` once near the root.
+ *
+ * Library code uses `useLinkComponent()` (or imports the already-wired
+ * `Link` re-export below) to read whatever the consumer registered.
+ */
+
+import {
+  AnchorHTMLAttributes,
+  ComponentPropsWithRef,
+  ComponentType,
+  createContext,
+  forwardRef,
+  ReactNode,
+  Ref,
+  useContext,
+} from 'react';
+
+export type LinkComponentProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
+  href: string;
+  children?: ReactNode;
+};
+
+export type LinkComponent = ComponentType<
+  LinkComponentProps & { ref?: Ref<HTMLAnchorElement> }
+>;
+
+const DefaultLink: LinkComponent = forwardRef<
+  HTMLAnchorElement,
+  LinkComponentProps
+>(function DefaultLink({ href, children, ...rest }, ref) {
+  return (
+    <a href={href} ref={ref} {...rest}>
+      {children}
+    </a>
+  );
+}) as LinkComponent;
+
+const LinkContext = createContext<LinkComponent>(DefaultLink);
+
+export type LinkProviderProps = {
+  /**
+   * The Link component used everywhere `@crudx/*` renders a navigable
+   * link (breadcrumbs, page-header back button, row "view"/"update"
+   * actions). When omitted, falls back to a plain `<a>`.
+   *
+   * Examples:
+   *
+   *   import NextLink from 'next/link';
+   *   <LinkProvider Link={NextLink}>...</LinkProvider>
+   *
+   *   import { Link as RouterLink } from 'react-router-dom';
+   *   <LinkProvider Link={RouterLink as any}>...</LinkProvider>
+   */
+  Link?: LinkComponent;
+  children?: ReactNode;
+};
+
+export const LinkProvider = ({ Link, children }: LinkProviderProps) => (
+  <LinkContext.Provider value={Link ?? DefaultLink}>
+    {children}
+  </LinkContext.Provider>
+);
+
+/** Read the currently-registered Link component. */
+export const useLinkComponent = (): LinkComponent => useContext(LinkContext);
+
+/**
+ * Drop-in `Link` that resolves through the provider at render time.
+ * Library components that previously imported `next/link` should swap
+ * to importing this instead.
+ */
+export const Link = forwardRef<
+  HTMLAnchorElement,
+  ComponentPropsWithRef<LinkComponent>
+>(function Link(props, ref) {
+  const Resolved = useContext(LinkContext);
+  return <Resolved {...props} ref={ref} />;
+});
+
+export default LinkProvider;

--- a/libs/common/src/components/index.ts
+++ b/libs/common/src/components/index.ts
@@ -1,3 +1,4 @@
 export * from './CloneElement';
 export * from './DateTime';
+export * from './LinkProvider';
 export * from './Money';

--- a/libs/mui/package.json
+++ b/libs/mui/package.json
@@ -19,7 +19,6 @@
     "@emotion/styled": "^11.0.0",
     "@mui/icons-material": "^5.0.0 || ^6.0.0 || ^7.0.0",
     "@mui/material": "^5.0.0 || ^6.0.0 || ^7.0.0",
-    "next": ">=13",
     "react": ">=17",
     "react-dom": ">=17"
   }

--- a/libs/mui/src/components/BreadcrumbView/index.tsx
+++ b/libs/mui/src/components/BreadcrumbView/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
+import { Link as CrudLink } from '@crudx/common';
 import Breadcrumbs from '@mui/material/Breadcrumbs';
 import Link from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
 import cn from 'classnames';
-import NextLink from 'next/link';
 
 import { BreadcrumbViewProps } from './props';
 import { StyledChip } from './styled';
@@ -43,7 +43,7 @@ export const BreadcrumbView: React.FC<BreadcrumbViewProps> = (props) => {
                 key={i}
                 href={url}
                 color="inherit"
-                component={NextLink}
+                component={CrudLink}
                 {...linkProps}
               >
                 <StyledChip icon={icon} label={label} {...chipProps} />
@@ -84,7 +84,7 @@ export const BreadcrumbView: React.FC<BreadcrumbViewProps> = (props) => {
             sx={{ display: 'flex', alignItems: 'center' }}
             color="inherit"
             underline="hover"
-            component={NextLink}
+            component={CrudLink}
             {...linkProps}
           >
             {icon}

--- a/libs/mui/src/views/CrudPageHeaderView/index.tsx
+++ b/libs/mui/src/views/CrudPageHeaderView/index.tsx
@@ -1,11 +1,11 @@
 import { memo } from 'react';
+import { Link as CrudLink } from '@crudx/common';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import Box from '@mui/material/Box';
 import Link from '@mui/material/Link';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import cn from 'classnames';
-import NextLink from 'next/link';
 
 import { BreadcrumbView } from '../../components/BreadcrumbView';
 import { RenderNodeView } from '../../components/RenderNodeView';
@@ -82,7 +82,7 @@ export const CrudPageHeaderView = memo((props: CrudPageHeaderViewProps) => {
               <Link
                 className="crud-page-header-title-back"
                 sx={{ display: 'flex', alignItems: 'center' }}
-                component={NextLink}
+                component={CrudLink}
                 href={backPath}
                 {...backPathProps}
               >

--- a/libs/mui/src/views/CrudPanelView/hooks/useCrudTableItemAction/index.tsx
+++ b/libs/mui/src/views/CrudPanelView/hooks/useCrudTableItemAction/index.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useMemo } from 'react';
+import { Link } from '@crudx/common';
 import {
   CrudCommonActionNode,
   CrudCommonActions,
@@ -18,7 +19,6 @@ import cn from 'classnames';
 import includes from 'lodash/includes';
 import isNil from 'lodash/isNil';
 import startCase from 'lodash/startCase';
-import Link from 'next/link';
 
 import { TooltipView } from '../../../../components/TooltipView';
 

--- a/libs/shadcn/src/components/BreadcrumbView/index.tsx
+++ b/libs/shadcn/src/components/BreadcrumbView/index.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import NextLink from 'next/link';
+import { Link as NextLink } from '@crudx/common';
 
 import { cn } from '../../lib/cn';
 

--- a/libs/shadcn/src/views/CrudPageHeaderView/index.tsx
+++ b/libs/shadcn/src/views/CrudPageHeaderView/index.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
+import { Link as NextLink } from '@crudx/common';
 import { ChevronLeft } from 'lucide-react';
-import NextLink from 'next/link';
 
 import { cn } from '../../lib/cn';
 import { BreadcrumbView } from '../../components/BreadcrumbView';

--- a/libs/shadcn/src/views/CrudPanelView/hooks/useCrudTableItemAction/index.tsx
+++ b/libs/shadcn/src/views/CrudPanelView/hooks/useCrudTableItemAction/index.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useMemo } from 'react';
+import { Link } from '@crudx/common';
 import {
   CrudCommonActionNode,
   CrudCommonActions,
@@ -11,7 +12,6 @@ import {
   Pencil,
   Trash2,
 } from 'lucide-react';
-import Link from 'next/link';
 import includes from 'lodash/includes';
 import isNil from 'lodash/isNil';
 import startCase from 'lodash/startCase';

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.8.5",
+    "@codesandbox/sandpack-react": "^2.13.5",
     "@emotion/react": "^11.11.1",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1379,6 +1379,148 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@codemirror/autocomplete@^6.0.0", "@codemirror/autocomplete@^6.4.0":
+  version "6.20.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz#4cfbc8b2e1e25f890ec34a081037e58b4e44143e"
+  integrity sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.17.0"
+    "@lezer/common" "^1.0.0"
+
+"@codemirror/commands@^6.1.3":
+  version "6.10.3"
+  resolved "https://registry.yarnpkg.com/@codemirror/commands/-/commands-6.10.3.tgz#01877060befdec352e8300dec1f185489c300635"
+  integrity sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.6.0"
+    "@codemirror/view" "^6.27.0"
+    "@lezer/common" "^1.1.0"
+
+"@codemirror/lang-css@^6.0.0", "@codemirror/lang-css@^6.0.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-css/-/lang-css-6.3.1.tgz#763ca41aee81bb2431be55e3cfcc7cc8e91421a3"
+  integrity sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@lezer/common" "^1.0.2"
+    "@lezer/css" "^1.1.7"
+
+"@codemirror/lang-html@^6.4.0":
+  version "6.4.11"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-html/-/lang-html-6.4.11.tgz#c46ba46ae642fd567cf05c4129005d2913ac248d"
+  integrity sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/lang-css" "^6.0.0"
+    "@codemirror/lang-javascript" "^6.0.0"
+    "@codemirror/language" "^6.4.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.17.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/css" "^1.1.0"
+    "@lezer/html" "^1.3.12"
+
+"@codemirror/lang-javascript@^6.0.0", "@codemirror/lang-javascript@^6.1.2":
+  version "6.2.5"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz#b9ea6b2f0383ed6895fae7888c0322541538f10a"
+  integrity sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/language" "^6.6.0"
+    "@codemirror/lint" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.17.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/javascript" "^1.0.0"
+
+"@codemirror/language@^6.0.0", "@codemirror/language@^6.3.2", "@codemirror/language@^6.4.0", "@codemirror/language@^6.6.0":
+  version "6.12.3"
+  resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-6.12.3.tgz#0b220182973a4c19850b29f7dd82aec1bbae3d7e"
+  integrity sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.23.0"
+    "@lezer/common" "^1.5.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+    style-mod "^4.0.0"
+
+"@codemirror/lint@^6.0.0":
+  version "6.9.5"
+  resolved "https://registry.yarnpkg.com/@codemirror/lint/-/lint-6.9.5.tgz#c7da006f3335a33014799a7375c82df558e89f90"
+  integrity sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.35.0"
+    crelt "^1.0.5"
+
+"@codemirror/state@^6.0.0", "@codemirror/state@^6.2.0", "@codemirror/state@^6.6.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.6.0.tgz#b88dbdc14aea4ace3c6d67bb77fe28bb84e4394e"
+  integrity sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==
+  dependencies:
+    "@marijn/find-cluster-break" "^1.0.0"
+
+"@codemirror/view@^6.17.0", "@codemirror/view@^6.23.0", "@codemirror/view@^6.27.0", "@codemirror/view@^6.35.0", "@codemirror/view@^6.7.1":
+  version "6.41.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.41.1.tgz#8ecb39af289e7d03df0f3fb6e3c9b1f8747839bf"
+  integrity sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==
+  dependencies:
+    "@codemirror/state" "^6.6.0"
+    crelt "^1.0.6"
+    style-mod "^4.1.0"
+    w3c-keyname "^2.2.4"
+
+"@codesandbox/nodebox@0.1.8":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@codesandbox/nodebox/-/nodebox-0.1.8.tgz#2dc701005cedefac386f17a69a4c9a4f38c2325d"
+  integrity sha512-2VRS6JDSk+M+pg56GA6CryyUSGPjBEe8Pnae0QL3jJF1mJZJVMDKr93gJRtBbLkfZN6LD/DwMtf+2L0bpWrjqg==
+  dependencies:
+    outvariant "^1.4.0"
+    strict-event-emitter "^0.4.3"
+
+"@codesandbox/sandpack-client@^2.19.8":
+  version "2.19.8"
+  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-client/-/sandpack-client-2.19.8.tgz#45f936179aa8e012f11285ddd830911e6260a0f7"
+  integrity sha512-CMV4nr1zgKzVpx4I3FYvGRM5YT0VaQhALMW9vy4wZRhEyWAtJITQIqZzrTGWqB1JvV7V72dVEUCUPLfYz5hgJQ==
+  dependencies:
+    "@codesandbox/nodebox" "0.1.8"
+    buffer "^6.0.3"
+    dequal "^2.0.2"
+    mime-db "^1.52.0"
+    outvariant "1.4.0"
+    static-browser-server "1.0.3"
+
+"@codesandbox/sandpack-react@^2.13.5":
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-react/-/sandpack-react-2.20.0.tgz#b298ad7159d01ae415a35612738a68251bc01323"
+  integrity sha512-takd1YpW/PMQ6KPQfvseWLHWklJovGY8QYj8MtWnskGKbjOGJ6uZfyZbcJ6aCFLQMpNyjTqz9AKNbvhCOZ1TUQ==
+  dependencies:
+    "@codemirror/autocomplete" "^6.4.0"
+    "@codemirror/commands" "^6.1.3"
+    "@codemirror/lang-css" "^6.0.1"
+    "@codemirror/lang-html" "^6.4.0"
+    "@codemirror/lang-javascript" "^6.1.2"
+    "@codemirror/language" "^6.3.2"
+    "@codemirror/state" "^6.2.0"
+    "@codemirror/view" "^6.7.1"
+    "@codesandbox/sandpack-client" "^2.19.8"
+    "@lezer/highlight" "^1.1.3"
+    "@react-hook/intersection-observer" "^3.1.1"
+    "@stitches/core" "^1.2.6"
+    anser "^2.1.1"
+    clean-set "^1.1.2"
+    dequal "^2.0.2"
+    escape-carriage "^1.3.1"
+    lz-string "^1.4.4"
+    react-devtools-inline "4.4.0"
+    react-is "^17.0.2"
+
 "@colors/colors@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
@@ -2433,6 +2575,57 @@
     inquirer "8.2.5"
     rxjs "7.8.1"
 
+"@lezer/common@^1.0.0", "@lezer/common@^1.0.2", "@lezer/common@^1.1.0", "@lezer/common@^1.2.0", "@lezer/common@^1.3.0", "@lezer/common@^1.5.0":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@lezer/common/-/common-1.5.2.tgz#d6840db13779e3f1b42e70c9a97c4086d12fae22"
+  integrity sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==
+
+"@lezer/css@^1.1.0", "@lezer/css@^1.1.7":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@lezer/css/-/css-1.3.3.tgz#b9800a57b338985c34be0dcaa1638ddf5cba0df1"
+  integrity sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.3.0"
+
+"@lezer/highlight@^1.0.0", "@lezer/highlight@^1.1.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@lezer/highlight/-/highlight-1.2.3.tgz#a20f324b71148a2ea9ba6ff42e58bbfaec702857"
+  integrity sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==
+  dependencies:
+    "@lezer/common" "^1.3.0"
+
+"@lezer/html@^1.3.12":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@lezer/html/-/html-1.3.13.tgz#6a1305ae3bd2c9c01f877f8a8dc1e15ec652d01c"
+  integrity sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@lezer/javascript@^1.0.0":
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/@lezer/javascript/-/javascript-1.5.4.tgz#11746955f957d33c0933f17d7594db54a8b4beea"
+  integrity sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.1.3"
+    "@lezer/lr" "^1.3.0"
+
+"@lezer/lr@^1.0.0", "@lezer/lr@^1.3.0":
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/@lezer/lr/-/lr-1.4.10.tgz#b3acc36e5ad049b74ddb7719594e7e74d9161ff5"
+  integrity sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==
+  dependencies:
+    "@lezer/common" "^1.0.0"
+
+"@marijn/find-cluster-break@^1.0.0":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz#775374306116d51c0c500b8c4face0f9a04752d8"
+  integrity sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==
+
 "@mui/base@5.0.0-beta.24":
   version "5.0.0-beta.24"
   resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-beta.24.tgz#1a0638388291828dacf9547b466bc21fbaad3a2a"
@@ -2991,6 +3184,11 @@
     tslib "^2.3.0"
     yargs-parser "21.1.1"
 
+"@open-draft/deferred-promise@^2.1.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz#4a822d10f6f0e316be4d67b4d4f8c9a124b073bd"
+  integrity sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==
+
 "@parcel/watcher@2.0.4":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@parcel/watcher/-/watcher-2.0.4.tgz#f300fef4cc38008ff4b8c29d92588eced3ce014b"
@@ -3441,6 +3639,19 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-1.1.1.tgz#78244efe12930c56fd255d7923865857c41ac8cb"
   integrity sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==
 
+"@react-hook/intersection-observer@^3.1.1":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@react-hook/intersection-observer/-/intersection-observer-3.1.2.tgz#f6f0e42588e03c4afeac0276889d97927d67edc7"
+  integrity sha512-mWU3BMkmmzyYMSuhO9wu3eJVP21N8TcgYm9bZnTrMwuM818bEk+0NRM3hP+c/TqA9Ln5C7qE53p1H0QMtzYdvQ==
+  dependencies:
+    "@react-hook/passive-layout-effect" "^1.2.0"
+    intersection-observer "^0.10.0"
+
+"@react-hook/passive-layout-effect@^1.2.0":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@react-hook/passive-layout-effect/-/passive-layout-effect-1.2.1.tgz#c06dac2d011f36d61259aa1c6df4f0d5e28bc55e"
+  integrity sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==
+
 "@repeaterjs/repeater@^3.0.4":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@repeaterjs/repeater/-/repeater-3.0.4.tgz#a04d63f4d1bf5540a41b01a921c9a7fddc3bd1ca"
@@ -3552,6 +3763,11 @@
   integrity sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==
   dependencies:
     "@sinonjs/commons" "^3.0.0"
+
+"@stitches/core@^1.2.6":
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/@stitches/core/-/core-1.2.8.tgz#dce3b8fdc764fbc6dbea30c83b73bfb52cf96173"
+  integrity sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==
 
 "@svgr/babel-plugin-add-jsx-attribute@8.0.0":
   version "8.0.0"
@@ -4398,6 +4614,11 @@ animate.css@^4.1.1:
   resolved "https://registry.yarnpkg.com/animate.css/-/animate.css-4.1.1.tgz#614ec5a81131d7e4dc362a58143f7406abd68075"
   integrity sha512-+mRmCTv6SbCmtYJCN4faJMNFVNN5EuCTTprDTAo7YzIGji2KADmakjVA3+8mVDkZ2Bf09vayB35lSQIex2+QaQ==
 
+anser@^2.1.1:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/anser/-/anser-2.3.5.tgz#3435896b68b93e5e744842499d0ce3e6f6d013ee"
+  integrity sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==
+
 ansi-colors@^4.1.1:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.3.tgz#37611340eb2243e70cc604cad35d63270d48781b"
@@ -5049,6 +5270,14 @@ buffer@^5.5.0, buffer@^5.6.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
+
 builtin-modules@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
@@ -5315,6 +5544,11 @@ classnames@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
   integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
+
+clean-set@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/clean-set/-/clean-set-1.1.2.tgz#76d8bf238c3e27827bfa73073ecdfdc767187070"
+  integrity sha512-cA8uCj0qSoG9e0kevyOWXwPaELRPVg5Pxp6WskLMwerx257Zfnh8Nl0JBH59d7wQzij2CK7qEfJQK3RjuKKIug==
 
 clean-stack@^2.0.0:
   version "2.2.0"
@@ -5788,6 +6022,11 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+crelt@^1.0.5, crelt@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/crelt/-/crelt-1.0.6.tgz#7cc898ea74e190fb6ef9dae57f8f81cf7302df72"
+  integrity sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==
+
 cross-fetch@^3.1.5:
   version "3.1.8"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.8.tgz#0327eba65fd68a7d119f8fb2bf9334a1a7956f82"
@@ -6029,6 +6268,14 @@ cypress@^12.16.0:
     untildify "^4.0.0"
     yauzl "^2.10.0"
 
+d@1, d@^1.0.1, d@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/d/-/d-1.0.2.tgz#2aefd554b81981e7dccf72d6842ae725cb17e5de"
+  integrity sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==
+  dependencies:
+    es5-ext "^0.10.64"
+    type "^2.7.2"
+
 damerau-levenshtein@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
@@ -6218,7 +6465,7 @@ dependency-graph@^0.11.0:
   resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-0.11.0.tgz#ac0ce7ed68a54da22165a85e97a01d53f5eb2e27"
   integrity sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==
 
-dequal@^2.0.0, dequal@^2.0.3:
+dequal@^2.0.0, dequal@^2.0.2, dequal@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
@@ -6388,6 +6635,11 @@ dotenv@^16.0.0:
   version "16.3.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
   integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
+
+dotenv@^16.0.3:
+  version "16.6.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.6.1.tgz#773f0e69527a8315c7285d5ee73c4459d20a8020"
+  integrity sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==
 
 dotenv@~10.0.0:
   version "10.0.0"
@@ -6600,6 +6852,33 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
+es5-ext@^0.10.35, es5-ext@^0.10.62, es5-ext@^0.10.64, es5-ext@~0.10.14:
+  version "0.10.64"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.64.tgz#12e4ffb48f1ba2ea777f1fcdd1918ef73ea21714"
+  integrity sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==
+  dependencies:
+    es6-iterator "^2.0.3"
+    es6-symbol "^3.1.3"
+    esniff "^2.0.1"
+    next-tick "^1.1.0"
+
+es6-iterator@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
+  integrity sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==
+  dependencies:
+    d "1"
+    es5-ext "^0.10.35"
+    es6-symbol "^3.1.1"
+
+es6-symbol@^3, es6-symbol@^3.1.1, es6-symbol@^3.1.3:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.4.tgz#f4e7d28013770b4208ecbf3e0bf14d3bcb557b8c"
+  integrity sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==
+  dependencies:
+    d "^1.0.2"
+    ext "^1.7.0"
+
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
@@ -6609,6 +6888,11 @@ escalade@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
   integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
+
+escape-carriage@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/escape-carriage/-/escape-carriage-1.3.1.tgz#842658e5422497b1232585e517dc813fc6a86170"
+  integrity sha512-GwBr6yViW3ttx1kb7/Oh+gKQ1/TrhYwxKqVmg5gS+BK+Qe2KrOa/Vh7w3HPBvgGf0LfcDGoY9I6NHKoA5Hozhw==
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -6891,6 +7175,16 @@ eslint@~8.15.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
+esniff@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/esniff/-/esniff-2.0.1.tgz#a4d4b43a5c71c7ec51c51098c1d8a29081f9b308"
+  integrity sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==
+  dependencies:
+    d "^1.0.1"
+    es5-ext "^0.10.62"
+    event-emitter "^0.3.5"
+    type "^2.7.2"
+
 espree@^9.0.0, espree@^9.3.2, espree@^9.4.0:
   version "9.6.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-9.6.1.tgz#a2a17b8e434690a5432f2f8018ce71d331a48c6f"
@@ -6953,6 +7247,14 @@ esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+event-emitter@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
+  integrity sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
 
 eventemitter2@6.4.7:
   version "6.4.7"
@@ -7032,6 +7334,13 @@ expect@^29.0.0, expect@^29.6.2:
     jest-matcher-utils "^29.6.2"
     jest-message-util "^29.6.2"
     jest-util "^29.6.2"
+
+ext@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/ext/-/ext-1.7.0.tgz#0ea4383c0103d60e70be99e9a7f11027a33c4f5f"
+  integrity sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==
+  dependencies:
+    type "^2.7.2"
 
 extend@^3.0.0, extend@~3.0.2:
   version "3.0.2"
@@ -8029,7 +8338,7 @@ identity-obj-proxy@3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-ieee754@^1.1.13:
+ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -8175,6 +8484,11 @@ internal-slot@^1.0.3, internal-slot@^1.0.4, internal-slot@^1.0.5:
     get-intrinsic "^1.2.0"
     has "^1.0.3"
     side-channel "^1.0.4"
+
+intersection-observer@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.10.0.tgz#4d11d63c1ff67e21e62987be24d55218da1a1a69"
+  integrity sha512-fn4bQ0Xq8FTej09YC/jqKZwtijpvARlRp6wxL5WTA6yPe2YWSJ5RJh7Nm79rK2qB0wr6iDQzH60XGq5V/7u8YQ==
 
 invariant@^2.2.4:
   version "2.2.4"
@@ -9456,7 +9770,7 @@ lucide-react@^0.294.0:
   resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.294.0.tgz#dc406e1e7e2f722cf93218fe5b31cf3c95778817"
   integrity sha512-V7o0/VECSGbLHn3/1O67FUgBwWB+hmzshrgDVRJQhMh8uj5D3HBuIvhuAmQTtlupILSplwIZg5FTc4tTKMA2SA==
 
-lz-string@^1.5.0:
+lz-string@^1.4.4, lz-string@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
   integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
@@ -10035,6 +10349,11 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
+mime-db@^1.52.0:
+  version "1.54.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
+  integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
+
 mime-types@^2.1.12, mime-types@^2.1.27, mime-types@~2.1.19:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
@@ -10196,6 +10515,11 @@ neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
+next-tick@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
+  integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
 
 next-translate@^2.5.3:
   version "2.5.3"
@@ -10623,6 +10947,16 @@ ospath@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/ospath/-/ospath-1.2.2.tgz#1276639774a3f8ef2572f7fe4280e0ea4550c07b"
   integrity sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==
+
+outvariant@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/outvariant/-/outvariant-1.4.0.tgz#e742e4bda77692da3eca698ef5bfac62d9fba06e"
+  integrity sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==
+
+outvariant@^1.3.0, outvariant@^1.4.0:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/outvariant/-/outvariant-1.4.3.tgz#221c1bfc093e8fec7075497e7799fdbf43d14873"
+  integrity sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==
 
 p-finally@^1.0.0:
   version "1.0.0"
@@ -11396,6 +11730,13 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
+react-devtools-inline@4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/react-devtools-inline/-/react-devtools-inline-4.4.0.tgz#e032a6eb17a9977b682306f84b46e683adf4bf68"
+  integrity sha512-ES0GolSrKO8wsKbsEkVeiR/ZAaHQTY4zDh1UW8DImVmm8oaGLl3ijJDvSGe+qDRKPZdPRnDtWWnSvvrgxXdThQ==
+  dependencies:
+    es6-symbol "^3"
+
 react-dom@18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
@@ -11416,7 +11757,7 @@ react-is@^16.13.1, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-is@^17.0.1:
+react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
@@ -12343,6 +12684,16 @@ stacktrace-js@^2.0.2:
     stack-generator "^2.0.5"
     stacktrace-gps "^3.0.4"
 
+static-browser-server@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/static-browser-server/-/static-browser-server-1.0.3.tgz#9030d141b99ed92c8eec1a7546b87548fd036f5d"
+  integrity sha512-ZUyfgGDdFRbZGGJQ1YhiM930Yczz5VlbJObrQLlk24+qNHVQx4OlLcYswEUo3bIyNAbQUIUR9Yr5/Hqjzqb4zA==
+  dependencies:
+    "@open-draft/deferred-promise" "^2.1.0"
+    dotenv "^16.0.3"
+    mime-db "^1.52.0"
+    outvariant "^1.3.0"
+
 stop-iteration-iterator@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz#6a60be0b4ee757d1ed5254858ec66b10c49285e4"
@@ -12354,6 +12705,11 @@ streamsearch@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
+
+strict-event-emitter@^0.4.3:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz#ff347c8162b3e931e3ff5f02cfce6772c3b07eb3"
+  integrity sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==
 
 string-env-interpolation@^1.0.1:
   version "1.0.1"
@@ -12502,6 +12858,11 @@ style-inject@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/style-inject/-/style-inject-0.3.0.tgz#d21c477affec91811cc82355832a700d22bf8dd3"
   integrity sha512-IezA2qp+vcdlhJaVm5SOdPPTUu0FCEqfNSli2vRuSIBbu5Nq5UvygTk/VzeCqfLz2Atj3dVII5QBKGZRZ0edzw==
+
+style-mod@^4.0.0, style-mod@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/style-mod/-/style-mod-4.1.3.tgz#6e9012255bb799bdac37e288f7671b5d71bf9f73"
+  integrity sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==
 
 style-to-js@^1.0.0:
   version "1.1.21"
@@ -13020,6 +13381,11 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
+type@^2.7.2:
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/type/-/type-2.7.3.tgz#436981652129285cc3ba94f392886c2637ea0486"
+  integrity sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==
+
 typed-array-buffer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz#18de3e7ed7974b0a729d3feecb94338d1472cd60"
@@ -13367,6 +13733,11 @@ vfile@^6.0.0:
   dependencies:
     "@types/unist" "^3.0.0"
     vfile-message "^4.0.0"
+
+w3c-keyname@^2.2.4:
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/w3c-keyname/-/w3c-keyname-2.2.8.tgz#7b17c8c6883d4e8b86ac8aba79d39e880f8869c5"
+  integrity sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==
 
 w3c-xmlserializer@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
# Summary of the changes

1. **Decouple UI libs from Next.js.** Introduced `LinkProvider` in  `@crudx/common`. `@crudx/mui` and `@crudx/shadcn` no longer import `next/link` directly — six internal call sites (BreadcrumbView, CrudPageHeaderView,  useCrudTableItemAction × 2 libs) now resolve the Link component through context.  Default = plain `<a>`, so the libs work in any React app out of the box. `next` is no longer in `@crudx/mui`'s `peerDependencies`. Consumers wrap their app once:  `<LinkProvider Link={NextLink as any}>` (or React Router, TanStack Router, …) to get client-side navigation back.
2. **Sandpack playground in `apps/example`.** New `/playground` route with four presets — MUI/shadcn × Table component / full CrudPanelView. Each preset's `dependencies` map points `@crudx/*` at the **npm registry**, so the live preview validates the actually-published bundles (not the workspace source). shadcn presets boot Tailwind via the Play CDN with the theme variables inlined into `index.html`.

---

## Reference to the cards / issues / tickets

fixes the "lib leaks `next` as a peer" complaint and adds a smoke-test surface for the npm-published packages.

---

## Screenshots / Videos / Examples

After the libs are republished as `1.1.0` (LinkProvider is a minor bump on the consumer surface), the playground exercises them at:

- `/playground` — landing
- `/playground/mui-table` — `Table` from `@crudx/mui`
- `/playground/shadcn-table` — `Table` from `@crudx/shadcn`
- `/playground/mui-crud` — `CrudPanelView` + `@crudx/rest-tanstack-adapter` (JSONPlaceholder)
- `/playground/shadcn-crud` — same flow on shadcn

Consumer migration for the LinkProvider change (one line near app root):

```tsx
// Next.js
import NextLink from 'next/link';
import { LinkProvider } from '@crudx/common';
<LinkProvider Link={NextLink as any}><App /></LinkProvider>

// React Router
import { Link as RouterLink } from 'react-router-dom';
<LinkProvider Link={RouterLink as any}><App /></LinkProvider>

// Plain <a> — no wrap needed (default)
```
---
Put an x in all the boxes that apply

Checklist
[x] I have performed a self-review of my own code, including:
    - Code is consistent with the project's style guidelines.
    - Code is well-organized and easy to read.
    - Code is adequately commented on where necessary.
[x] I did lint my code locally prior to pushing and resolved any issues found.
[x] The pull request fully complies with the project requirement
[x] The pull request does not introduce any security vulnerabilities.
[x] The pull request does not introduce new code smells, such as duplicate code or unnecessary complexity.
[x] The pull request has been tested locally or in a staging environment and is working with no bugs