### PR TITLE
Fix/link dependency

### DIFF
--- a/apps/example/src/data/playground-presets.ts
+++ b/apps/example/src/data/playground-presets.ts
@@ -307,7 +307,23 @@ function PostsPanel() {
 export default withQuery(PostsPanel);
 `;
 
+/**
+ * Transitive deps the published `@crudx/*` bundles need at runtime:
+ *
+ * - `dayjs` — `@crudx/common` uses it (DateTime / formatNumbering /
+ *   helpers/date) and ships it as a peer.
+ * - `next` — the currently-published 1.0.0 bundles of `@crudx/mui` and
+ *   `@crudx/shadcn` still import `next/link`. The LinkProvider refactor
+ *   on `main` removes that, so once the libs ship 1.0.1+ you can drop
+ *   `next` from this list.
+ */
+const TRANSITIVE_PEERS = {
+  dayjs: '^1.11.0',
+  next: '^13.4.0',
+};
+
 const MUI_TABLE_DEPS = {
+  ...TRANSITIVE_PEERS,
   '@crudx/common': CRUDX_VERSION,
   '@crudx/core': CRUDX_VERSION,
   '@crudx/mui': CRUDX_VERSION,
@@ -321,6 +337,7 @@ const MUI_TABLE_DEPS = {
 };
 
 const SHADCN_TABLE_DEPS = {
+  ...TRANSITIVE_PEERS,
   '@crudx/common': CRUDX_VERSION,
   '@crudx/core': CRUDX_VERSION,
   '@crudx/shadcn': CRUDX_VERSION,

--- a/apps/example/src/data/playground-presets.ts
+++ b/apps/example/src/data/playground-presets.ts
@@ -30,49 +30,109 @@ export type Preset = {
 const CRUDX_VERSION = '^1.0.0';
 
 /**
- * Inline `<style>` block holding the shadcn theme variables. Pasted
- * straight into the Sandpack `index.html` for the shadcn presets. We
- * also load Tailwind via the Play CDN so the classnames the lib emits
- * actually render — Tailwind normally runs on the consumer side.
+ * shadcn classnames (`bg-background`, `border-border`, …) need
+ * Tailwind's `colors.<token> = 'hsl(var(--<token>))'` extension AND
+ * the shadcn CSS variables on `:root`. Earlier attempts overrode
+ * `/public/index.html` with `<script src="cdn.tailwindcss.com">` +
+ * inline config; Sandpack's react-ts template didn't pick it up
+ * reliably (Play CDN never initialised, classes rendered with no
+ * colour at all).
+ *
+ * We now bootstrap from the entry script: load the Play CDN, set
+ * `tailwind.config`, append a `<style type="text/tailwindcss">` with
+ * the variables, then mount React. Deterministic — no HTML override.
  */
-const SHADCN_TAILWIND_HTML = `<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Crudx playground</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <style>
-      @layer base {
-        :root {
-          --background: 0 0% 100%;
-          --foreground: 222.2 47.4% 11.2%;
-          --muted: 210 40% 96.1%;
-          --muted-foreground: 215.4 16.3% 46.9%;
-          --popover: 0 0% 100%;
-          --popover-foreground: 222.2 47.4% 11.2%;
-          --card: 0 0% 100%;
-          --card-foreground: 222.2 47.4% 11.2%;
-          --border: 214.3 31.8% 91.4%;
-          --input: 214.3 31.8% 91.4%;
-          --primary: 222.2 47.4% 11.2%;
-          --primary-foreground: 210 40% 98%;
-          --secondary: 210 40% 96.1%;
-          --secondary-foreground: 222.2 47.4% 11.2%;
-          --accent: 210 40% 96.1%;
-          --accent-foreground: 222.2 47.4% 11.2%;
-          --destructive: 0 100% 50%;
-          --destructive-foreground: 210 40% 98%;
-          --ring: 215 20.2% 65.1%;
-          --radius: 0.5rem;
-        }
-      }
-    </style>
-  </head>
-  <body>
-    <div id="root"></div>
-  </body>
-</html>
+const SHADCN_TAILWIND_BOOTSTRAP = `const TAILWIND_CONFIG = {
+  darkMode: 'class',
+  theme: {
+    extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+    },
+  },
+};
+
+const SHADCN_VARS = \`@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 47.4% 11.2%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 47.4% 11.2%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 47.4% 11.2%;
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --primary: 222.2 47.4% 11.2%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --ring: 215 20.2% 65.1%;
+    --radius: 0.5rem;
+  }
+}\`;
+
+function loadTailwind() {
+  return new Promise<void>((resolve) => {
+    const script = document.createElement('script');
+    script.src = 'https://cdn.tailwindcss.com';
+    script.onload = () => {
+      // Configure Tailwind BEFORE any React render kicks in so the
+      // MutationObserver picks up shadcn's classnames as they're
+      // added to the DOM.
+      (window as any).tailwind.config = TAILWIND_CONFIG;
+      const style = document.createElement('style');
+      style.setAttribute('type', 'text/tailwindcss');
+      style.textContent = SHADCN_VARS;
+      document.head.appendChild(style);
+      resolve();
+    };
+    document.head.appendChild(script);
+  });
+}
 `;
 
 const MUI_INDEX_TSX = `import { createRoot } from 'react-dom/client';
@@ -81,7 +141,14 @@ import App from './App';
 createRoot(document.getElementById('root')!).render(<App />);
 `;
 
-const SHADCN_INDEX_TSX = MUI_INDEX_TSX;
+const SHADCN_INDEX_TSX = `${SHADCN_TAILWIND_BOOTSTRAP}
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+loadTailwind().then(() => {
+  createRoot(document.getElementById('root')!).render(<App />);
+});
+`;
 
 const MUI_TABLE_APP = `import { useState } from 'react';
 import { Table } from '@crudx/mui';
@@ -312,10 +379,11 @@ export default withQuery(PostsPanel);
  * Sandpack's React template doesn't auto-install peer deps, so we
  * spread these into every preset.
  *
- * From `@crudx/common`'s rollup `external` list (so they're not
- * bundled into common.esm.js):
+ * Mirrored from each lib's rollup `external` list (the source of truth
+ * for what consumers have to provide):
  *
- *   currency-symbol-map, dayjs, lodash, numeral
+ *   `@crudx/core`   → axios + the common set below
+ *   `@crudx/common` → currency-symbol-map, dayjs, lodash, numeral
  *
  * Plus `next` — the currently-published 1.0.0 bundles of `@crudx/mui`
  * and `@crudx/shadcn` still import `next/link`. The LinkProvider
@@ -323,6 +391,7 @@ export default withQuery(PostsPanel);
  * can drop `next` from this list.
  */
 const TRANSITIVE_PEERS = {
+  axios: '^1.6.0',
   'currency-symbol-map': '^5.1.0',
   dayjs: '^1.11.0',
   lodash: '^4.17.0',
@@ -398,11 +467,10 @@ export const PRESETS: Record<PresetSlug, Preset> = {
     slug: 'shadcn-table',
     title: 'shadcn · Table',
     description:
-      'Standalone Table component from @crudx/shadcn. Tailwind via the Play CDN, shadcn theme variables inlined into index.html.',
+      'Standalone Table component from @crudx/shadcn. Tailwind Play CDN + shadcn theme variables bootstrapped from index.tsx.',
     ui: 'shadcn',
     kind: 'component',
     files: {
-      '/public/index.html': SHADCN_TAILWIND_HTML,
       '/index.tsx': SHADCN_INDEX_TSX,
       '/App.tsx': SHADCN_TABLE_APP,
     },
@@ -430,7 +498,6 @@ export const PRESETS: Record<PresetSlug, Preset> = {
     ui: 'shadcn',
     kind: 'crud',
     files: {
-      '/public/index.html': SHADCN_TAILWIND_HTML,
       '/index.tsx': SHADCN_INDEX_TSX,
       '/crud.tsx': CRUD_REST_HOOK,
       '/App.tsx': SHADCN_CRUD_APP,

--- a/apps/example/src/data/playground-presets.ts
+++ b/apps/example/src/data/playground-presets.ts
@@ -308,18 +308,26 @@ export default withQuery(PostsPanel);
 `;
 
 /**
- * Transitive deps the published `@crudx/*` bundles need at runtime:
+ * Transitive deps the published `@crudx/*` bundles need at runtime.
+ * Sandpack's React template doesn't auto-install peer deps, so we
+ * spread these into every preset.
  *
- * - `dayjs` — `@crudx/common` uses it (DateTime / formatNumbering /
- *   helpers/date) and ships it as a peer.
- * - `next` — the currently-published 1.0.0 bundles of `@crudx/mui` and
- *   `@crudx/shadcn` still import `next/link`. The LinkProvider refactor
- *   on `main` removes that, so once the libs ship 1.0.1+ you can drop
- *   `next` from this list.
+ * From `@crudx/common`'s rollup `external` list (so they're not
+ * bundled into common.esm.js):
+ *
+ *   currency-symbol-map, dayjs, lodash, numeral
+ *
+ * Plus `next` — the currently-published 1.0.0 bundles of `@crudx/mui`
+ * and `@crudx/shadcn` still import `next/link`. The LinkProvider
+ * refactor on `main` removes that, so once the libs ship 1.0.1+ you
+ * can drop `next` from this list.
  */
 const TRANSITIVE_PEERS = {
+  'currency-symbol-map': '^5.1.0',
   dayjs: '^1.11.0',
+  lodash: '^4.17.0',
   next: '^13.4.0',
+  numeral: '^2.0.0',
 };
 
 const MUI_TABLE_DEPS = {
@@ -332,7 +340,6 @@ const MUI_TABLE_DEPS = {
   '@emotion/react': '^11.11.0',
   '@emotion/styled': '^11.11.0',
   classnames: '^2.3.0',
-  lodash: '^4.17.0',
   'react-hot-toast': '^2.4.0',
 };
 

--- a/apps/example/src/pages/playground/index.tsx
+++ b/apps/example/src/pages/playground/index.tsx
@@ -11,8 +11,8 @@ import Link from 'next/link';
 import { AppBar } from '../../components';
 import {
   DemoKind,
-  PRESETS,
   PRESET_ORDER,
+  PRESETS,
   PresetSlug,
   UiKind,
 } from '../../data/playground-presets';
@@ -47,7 +47,9 @@ export default function PlaygroundIndexPage() {
           <h1 className="text-3xl font-bold tracking-tight">Playground</h1>
           <p className="mt-2 text-zinc-600">
             Each preset boots a Sandpack sandbox that installs{' '}
-            <code className="rounded bg-zinc-100 px-1.5 py-0.5 text-sm">@crudx/*</code>{' '}
+            <code className="rounded bg-zinc-100 px-1.5 py-0.5 text-sm">
+              @crudx/*
+            </code>{' '}
             from npm — so you're exercising the actually-published bundle, not
             the workspace source. Edit the code on the left, see the rendered
             output on the right.
@@ -96,8 +98,8 @@ export default function PlaygroundIndexPage() {
         </ul>
 
         <p className="mt-8 text-xs text-zinc-500">
-          Sandpack pulls dependencies from the public npm registry. If a
-          preset fails to load, double-check that the matching{' '}
+          Sandpack pulls dependencies from the public npm registry. If a preset
+          fails to load, double-check that the matching{' '}
           <code className="rounded bg-zinc-100 px-1 py-0.5">@crudx/*</code>{' '}
           version has actually been published.
         </p>


### PR DESCRIPTION
# Summary of the changes                          

Three follow-ups that get the Sandpack playground working against the actually-published `@crudx/*@1.0.0` bundles.
                                              
1. `next` + `dayjs`** (`bb4d6e3`). The 1.0.0 mui/shadcn bundles still  import `next/link` (LinkProvider hasn't shipped a release yet), and `@crudx/common` uses `dayjs` directly. Added both to a shared `TRANSITIVE_PEERS` map spread into every preset's `dependencies`. `next` flagged in a comment as droppable once 1.0.1 ships.                                                       
2. full peer audit** (`0152ac2`). Cross-referenced each lib's rollup  `external` list against the playground deps and lifted everything missing into `TRANSITIVE_PEERS` (`currency-symbol-map`, `numeral`, `lodash`, plus `axios` for `@crudx/core`'s file-uploader hook). Dropped the duplicate `lodash` from the MUI preset.                                                                           
3. fix shadcn Tailwind bootstrap** (`5436b71`). The earlier `/public/index.html` override wasn't honored by Sandpack's react-ts template. Moved Tailwind setup into the entry script: `index.tsx` now appends `<script src="cdn.tailwindcss.com">`, sets `tailwind.config` with the shadcn token extension, drops a `<style type="text/tailwindcss">` with `:root` variables, then mounts React. Deterministic and template-agnostic

---

## Reference to the cards / issues / tickets
                                          
n/a — iterating on the Sandpack playground introduced in #21 (`feat(example): add Sandpack playground`)
  
---

## Screenshots / Videos / Examples

After this change the four playground routes all render the published bundles correctly:
- `/playground/mui-table` — MUI Table renders rows, sortable header, pagination
- `/playground/shadcn-table` — shadcn Table renders with proper colours + radii (the Round 3 fix)
- `/playground/mui-crud` — full `CrudPanelView` against JSONPlaceholder
- `/playground/shadcn-crud` — same flow, shadcn variant
 
Edit on the left, preview on the right. If any future preset breaks with a "Could not find dependency: X", check the corresponding lib's `project.json → external` list and add the missing entry to `TRANSITIVE_PEERS`.

---

Put an `x` in all the boxes that apply      

## Checklist

- [x] I have performed a self-review of my own code, including:
    - Code is consistent with the project's style guidelines.
    - Code is well-organized and easy to read.
    - Code is adequately commented on where necessary
- [x] I did lint my code locally prior to pushing and resolved any issues found
- [x] The pull request fully complies with the project requirement
- [x] The pull request does not introduce any security vulnerabilities.
- [x] The pull request does not introduce new code smells, such as duplicate code or unnecessary complexity.
- [x] The pull request has been tested locally or in a staging environment and is working with no bugs