### PR TITLE
Feat/shadcn table style

### DIFF
--- a/apps/example/src/pages/components-shadcn.tsx
+++ b/apps/example/src/pages/components-shadcn.tsx
@@ -27,7 +27,7 @@ import {
   TabView,
   TooltipView,
 } from '@crudx/shadcn';
-import { Edit, Heart, Home } from 'lucide-react';
+import { Edit, Heart, Home, Trash2 } from 'lucide-react';
 
 import { AppBar } from '../components';
 
@@ -162,6 +162,98 @@ function TableDemo() {
       onPageChange={setPage}
       onPageSizeChange={setPageSize}
     />
+  );
+}
+
+type StickyRow = {
+  id: number;
+  name: string;
+  email: string;
+  team: string;
+  role: string;
+  city: string;
+  country: string;
+  joined: string;
+  salary: number;
+  status: string;
+};
+
+const STICKY_ROWS: StickyRow[] = [
+  { id: 1, name: 'Ada Lovelace', email: 'ada@analytical.engine', team: 'Engineering', role: 'Principal Engineer', city: 'London', country: 'United Kingdom', joined: '1843-12-10', salary: 215000, status: 'Active' },
+  { id: 2, name: 'Alan Turing', email: 'alan@bletchley.uk', team: 'Research', role: 'Cryptographer', city: 'Manchester', country: 'United Kingdom', joined: '1936-06-12', salary: 198000, status: 'Active' },
+  { id: 3, name: 'Grace Hopper', email: 'grace@navy.mil', team: 'Compilers', role: 'Rear Admiral', city: 'Arlington', country: 'United States', joined: '1944-07-02', salary: 184000, status: 'Active' },
+  { id: 4, name: 'Katherine Johnson', email: 'katherine@nasa.gov', team: 'Trajectory', role: 'Mathematician', city: 'Hampton', country: 'United States', joined: '1953-06-18', salary: 172000, status: 'Active' },
+  { id: 5, name: 'Hedy Lamarr', email: 'hedy@spread.spectrum', team: 'Comms', role: 'Inventor', city: 'Vienna', country: 'Austria', joined: '1942-08-11', salary: 165000, status: 'Pending' },
+  { id: 6, name: 'Tim Berners-Lee', email: 'timbl@cern.ch', team: 'Web Platform', role: 'Director', city: 'Geneva', country: 'Switzerland', joined: '1989-03-12', salary: 240000, status: 'Active' },
+  { id: 7, name: 'Margaret Hamilton', email: 'margaret@mit.edu', team: 'Apollo', role: 'Software Lead', city: 'Cambridge', country: 'United States', joined: '1965-09-01', salary: 202000, status: 'On leave' },
+];
+
+const STICKY_COLUMNS = [
+  { key: 'id', title: '#', width: 60, dataIndex: 'id' as const, align: 'center' as const },
+  { key: 'name', title: 'Name', width: 180, dataIndex: 'name' as const, sortable: true },
+  { key: 'email', title: 'Email', width: 240, dataIndex: 'email' as const },
+  { key: 'team', title: 'Team', width: 140, dataIndex: 'team' as const },
+  { key: 'role', title: 'Role', width: 200, dataIndex: 'role' as const },
+  { key: 'city', title: 'City', width: 150, dataIndex: 'city' as const },
+  { key: 'country', title: 'Country', width: 180, dataIndex: 'country' as const },
+  { key: 'joined', title: 'Joined', width: 130, dataIndex: 'joined' as const },
+  {
+    key: 'salary',
+    title: 'Salary',
+    width: 130,
+    align: 'right' as const,
+    render: (_: unknown, record: StickyRow) => (
+      <NumberFormatView amount={record.salary} format="0,0" prefix="$" />
+    ),
+  },
+  { key: 'status', title: 'Status', width: 120, dataIndex: 'status' as const },
+  {
+    key: 'action',
+    title: 'Action',
+    width: 110,
+    sticky: true,
+    align: 'center' as const,
+    render: () => (
+      <div className="flex items-center justify-center gap-1">
+        <button
+          type="button"
+          aria-label="Edit"
+          className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border text-muted-foreground hover:bg-accent hover:text-foreground"
+        >
+          <Edit className="h-3.5 w-3.5" />
+        </button>
+        <button
+          type="button"
+          aria-label="Delete"
+          className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    ),
+  },
+];
+
+function TableStickyDemo() {
+  return (
+    <div className="max-w-full">
+      <p className="mb-2 text-xs text-muted-foreground">
+        Scroll horizontally — the checkbox column stays pinned to the left and
+        the action column stays pinned to the right. Inset shadows mark the
+        sticky boundaries.
+      </p>
+      <Table<StickyRow>
+        data={STICKY_ROWS}
+        columns={STICKY_COLUMNS}
+        bordered
+        pagination={false}
+        checkbox={{
+          enabled: true,
+          sticky: true,
+          dataIndex: 'id',
+        }}
+      />
+    </div>
   );
 }
 
@@ -531,6 +623,34 @@ export function ComponentsShadcnPage() {
 />`}
           >
             <TableDemo />
+          </Section>
+
+          <Section
+            name="Table — sticky columns"
+            importLine={`import { Table } from '@crudx/shadcn';`}
+            description="Pin the checkbox column to the left edge with `checkbox.sticky` and pin a column (e.g. an action column) to the right edge with `sticky: true`. Cumulative offsets and inset boundary shadows are applied automatically."
+            code={`<Table<Row>
+  data={rows}
+  bordered
+  pagination={false}
+  checkbox={{ enabled: true, sticky: true, dataIndex: 'id' }}
+  columns={[
+    { key: 'id',     title: '#',      width: 60,  dataIndex: 'id' },
+    { key: 'name',   title: 'Name',   width: 180, dataIndex: 'name', sortable: true },
+    { key: 'email',  title: 'Email',  width: 240, dataIndex: 'email' },
+    /* …more columns to force horizontal scroll… */
+    {
+      key: 'action',
+      title: 'Action',
+      width: 110,
+      sticky: true,                       /* pin to right edge */
+      align: 'center',
+      render: () => <RowActions />,
+    },
+  ]}
+/>`}
+          >
+            <TableStickyDemo />
           </Section>
 
           <Section

--- a/libs/shadcn/src/adapters/column-sticky.ts
+++ b/libs/shadcn/src/adapters/column-sticky.ts
@@ -1,11 +1,14 @@
 import { TableColumnType } from '../@types';
 
+export const STICKY_CHECKBOX_WIDTH = 44;
+
 export interface StickyState {
   isFirstSticky: boolean;
   isPrevSticky: boolean;
   isNextSticky: boolean;
   hideBorderLeft: boolean;
   hideBorderRight: boolean;
+  side?: 'left' | 'right';
 }
 
 /**
@@ -27,11 +30,106 @@ export function getColumnStickyState<TData>(
   const isNextSticky = !isLastItem && !!columns[index + 1]?.sticky;
   const hideBorderLeft = (isFirstSticky || isPrevSticky) && !isLastItem;
   const hideBorderRight = isLastItem || isNextSticky;
+  const side: StickyState['side'] = getStickySide(columns, index);
   return {
     isFirstSticky,
     isPrevSticky,
     isNextSticky,
     hideBorderLeft,
     hideBorderRight,
+    side,
   };
+}
+
+/**
+ * Determine which edge a sticky column anchors to.
+ *
+ * - Columns 0..i all sticky    → 'left'  (left block)
+ * - Columns i..last all sticky → 'right' (right block)
+ * - Otherwise (isolated sticky in middle) → 'right' default
+ */
+export function getStickySide<TData>(
+  columns: TableColumnType<TData>[],
+  index: number
+): 'left' | 'right' | undefined {
+  const col = columns[index];
+  if (!col?.sticky) return undefined;
+  if (isInLeftStickyBlock(columns, index)) return 'left';
+  if (isInRightStickyBlock(columns, index)) return 'right';
+  return 'right';
+}
+
+function isInLeftStickyBlock<TData>(
+  columns: TableColumnType<TData>[],
+  index: number
+): boolean {
+  for (let i = 0; i <= index; i++) {
+    if (!columns[i]?.sticky) return false;
+  }
+  return true;
+}
+
+function isInRightStickyBlock<TData>(
+  columns: TableColumnType<TData>[],
+  index: number
+): boolean {
+  for (let i = index; i < columns.length; i++) {
+    if (!columns[i]?.sticky) return false;
+  }
+  return true;
+}
+
+const widthToPx = (w: number | string | undefined): number => {
+  if (w == null) return 0;
+  if (typeof w === 'number') return w;
+  const match = /^(\d+(?:\.\d+)?)(?:px)?$/i.exec(w.trim());
+  return match ? parseFloat(match[1]) : 0;
+};
+
+export interface ColumnPinningStyle {
+  side: 'left' | 'right' | undefined;
+  offset: number;
+  isLastLeftPinned: boolean;
+  isFirstRightPinned: boolean;
+}
+
+/**
+ * Mirrors TanStack's `getCommonPinningStyles` helper. Returns the cumulative
+ * inset offset (px) and boundary flags for a sticky column, accounting for
+ * a sticky checkbox column on the left edge.
+ */
+export function getColumnPinningStyle<TData>(
+  columns: TableColumnType<TData>[],
+  index: number,
+  hasCheckBoxSticky: boolean
+): ColumnPinningStyle {
+  const side = getStickySide(columns, index);
+  if (!side) {
+    return {
+      side: undefined,
+      offset: 0,
+      isLastLeftPinned: false,
+      isFirstRightPinned: false,
+    };
+  }
+
+  let offset = 0;
+  if (side === 'left') {
+    if (hasCheckBoxSticky) offset += STICKY_CHECKBOX_WIDTH;
+    for (let i = 0; i < index; i++) {
+      if (columns[i]?.sticky) offset += widthToPx(columns[i].width);
+    }
+  } else {
+    for (let i = index + 1; i < columns.length; i++) {
+      if (columns[i]?.sticky) offset += widthToPx(columns[i].width);
+    }
+  }
+
+  const isLastLeftPinned =
+    side === 'left' &&
+    (index === columns.length - 1 || !columns[index + 1]?.sticky);
+  const isFirstRightPinned =
+    side === 'right' && (index === 0 || !columns[index - 1]?.sticky);
+
+  return { side, offset, isLastLeftPinned, isFirstRightPinned };
 }

--- a/libs/shadcn/src/adapters/use-sticky-offsets.ts
+++ b/libs/shadcn/src/adapters/use-sticky-offsets.ts
@@ -1,0 +1,122 @@
+import {
+  createContext,
+  RefObject,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+import { TableColumnType } from '../@types';
+
+import { getStickySide } from './column-sticky';
+
+/**
+ * ===========================
+ * Runtime sticky offset measurement
+ * ===========================
+ *
+ * The static `getColumnPinningStyle` helper in `./column-sticky` computes
+ * cumulative `left` / `right` offsets from the column config — but it can
+ * only see widths declared as numbers or `"NNpx"`. Anything in `%`, `rem`,
+ * `auto`, or driven by content gets a 0 width, which makes stacked sticky
+ * columns overlap.
+ *
+ * `useStickyOffsets` measures the rendered `<th>` widths from the DOM
+ * (after layout) and re-measures via `ResizeObserver`, then exposes the
+ * results through a context so head + body cells agree on the same
+ * offsets. The static helper remains the first-paint / SSR fallback.
+ */
+
+export type StickyOffset = { left?: number; right?: number };
+
+export interface MeasuredOffsets {
+  get(columnKey: string): StickyOffset | undefined;
+}
+
+const NOOP_OFFSETS: MeasuredOffsets = { get: () => undefined };
+
+export const StickyOffsetsContext =
+  createContext<MeasuredOffsets>(NOOP_OFFSETS);
+
+export const useStickyOffsetsContext = (): MeasuredOffsets =>
+  useContext(StickyOffsetsContext);
+
+const escapeAttr = (val: string): string =>
+  val.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
+const offsetsEqual = (
+  a: Map<string, StickyOffset>,
+  b: Map<string, StickyOffset>
+): boolean => {
+  if (a.size !== b.size) return false;
+  for (const [key, value] of a) {
+    const other = b.get(key);
+    if (!other) return false;
+    if (other.left !== value.left || other.right !== value.right) return false;
+  }
+  return true;
+};
+
+export const useStickyOffsets = <TData,>(
+  columns: TableColumnType<TData>[],
+  hasCheckBoxSticky: boolean,
+  tableRef: RefObject<HTMLTableElement>
+): MeasuredOffsets => {
+  const [offsets, setOffsets] = useState<Map<string, StickyOffset>>(
+    () => new Map()
+  );
+
+  useEffect(() => {
+    const table = tableRef.current;
+    if (!table) return;
+
+    const measure = () => {
+      const next = new Map<string, StickyOffset>();
+
+      const checkboxTh = table.querySelector<HTMLElement>(
+        'thead .crudx-checkbox-column'
+      );
+      const checkboxWidth =
+        hasCheckBoxSticky && checkboxTh ? checkboxTh.offsetWidth : 0;
+
+      let leftAcc = checkboxWidth;
+      for (let i = 0; i < columns.length; i++) {
+        const col = columns[i];
+        if (getStickySide(columns, i) !== 'left') continue;
+        next.set(col.key, { left: leftAcc });
+        const th = table.querySelector<HTMLElement>(
+          `thead [data-key="${escapeAttr(col.key)}"]`
+        );
+        leftAcc += th?.offsetWidth ?? 0;
+      }
+
+      let rightAcc = 0;
+      for (let i = columns.length - 1; i >= 0; i--) {
+        const col = columns[i];
+        if (getStickySide(columns, i) !== 'right') continue;
+        next.set(col.key, { right: rightAcc });
+        const th = table.querySelector<HTMLElement>(
+          `thead [data-key="${escapeAttr(col.key)}"]`
+        );
+        rightAcc += th?.offsetWidth ?? 0;
+      }
+
+      setOffsets((prev) => (offsetsEqual(prev, next) ? prev : next));
+    };
+
+    measure();
+
+    if (typeof ResizeObserver === 'undefined') return;
+
+    const observer = new ResizeObserver(measure);
+    table.querySelectorAll('thead th').forEach((th) => observer.observe(th));
+
+    return () => observer.disconnect();
+  }, [columns, hasCheckBoxSticky, tableRef]);
+
+  return useMemo<MeasuredOffsets>(
+    () => ({ get: (key: string) => offsets.get(key) }),
+    [offsets]
+  );
+};

--- a/libs/shadcn/src/components/Table/index.tsx
+++ b/libs/shadcn/src/components/Table/index.tsx
@@ -1,9 +1,13 @@
-import { PropsWithChildren, useState } from 'react';
+import { PropsWithChildren, useRef, useState } from 'react';
 import { useDeepCompareEffect } from '@crudx/common';
 import isNil from 'lodash/isNil';
 import uniq from 'lodash/uniq';
 
 import { InferDataColumnType } from '../../@types';
+import {
+  StickyOffsetsContext,
+  useStickyOffsets,
+} from '../../adapters/use-sticky-offsets';
 import { extractCheckboxValue } from '../../adapters/use-table-state';
 import { cn } from '../../lib/cn';
 import { Skeleton } from '../../primitives/skeleton';
@@ -88,6 +92,9 @@ export const Table = <TData,>(props: PropsWithChildren<TableProps<TData>>) => {
     ...restProps
   } = props;
 
+  // =============== REFS
+  const tableRef = useRef<HTMLTableElement>(null);
+
   // =============== STATE
   const [checkedState, setCheckedState] =
     useState<InferDataColumnType<TData>[]>(checked);
@@ -98,6 +105,12 @@ export const Table = <TData,>(props: PropsWithChildren<TableProps<TData>>) => {
   const hasDefinedTotal = !isNil(total);
   const hasChecked = checkedState?.length > 0;
   const enableCheckbox = checkbox?.enabled ?? false;
+  const hasCheckBoxStickyComputed = enableCheckbox && (checkbox?.sticky ?? false);
+  const measuredStickyOffsets = useStickyOffsets(
+    columns,
+    hasCheckBoxStickyComputed,
+    tableRef
+  );
   const columnLength = enableCheckbox ? columns.length + 1 : columns.length;
   const hasStickySet = !isNil(stickyHeader);
   const isStickyEnabled =
@@ -275,44 +288,47 @@ export const Table = <TData,>(props: PropsWithChildren<TableProps<TData>>) => {
         }}
       >
         {/* =============== TABLE */}
-        <table
-          className={cn(
-            'crudx-table',
-            `crudx-style-${borderStyle}`,
-            tableVariants({
-              striped,
-              bordered,
-              borderStyle,
-              size: normalizedSize,
-            }),
-            className
-          )}
-          style={tableInlineVars}
-          {...restProps}
-        >
-          {/* =============== TABLE HEAD */}
-          <TableHead
-            columns={columns}
-            checkbox={checkbox}
-            sticky={isStickyEnabled}
-            borderTop={tableHeadBorderTop}
-            borderBottom={tableHeadBorderBottom}
-            onSort={onColumnSort}
-            checked={getCheckedStatus()}
-            onCheckAll={onHandleCheckAll}
-            {...tableHeadProps}
-          />
+        <StickyOffsetsContext.Provider value={measuredStickyOffsets}>
+          <table
+            ref={tableRef}
+            className={cn(
+              'crudx-table',
+              `crudx-style-${borderStyle}`,
+              tableVariants({
+                striped,
+                bordered,
+                borderStyle,
+                size: normalizedSize,
+              }),
+              className
+            )}
+            style={tableInlineVars}
+            {...restProps}
+          >
+            {/* =============== TABLE HEAD */}
+            <TableHead
+              columns={columns}
+              checkbox={checkbox}
+              sticky={isStickyEnabled}
+              borderTop={tableHeadBorderTop}
+              borderBottom={tableHeadBorderBottom}
+              onSort={onColumnSort}
+              checked={getCheckedStatus()}
+              onCheckAll={onHandleCheckAll}
+              {...tableHeadProps}
+            />
 
-          {/* =============== TABLE BODY */}
-          <tbody {...tableBodyProps}>
-            {renderTableBodyContent()}
-            {/* extra view with `children` */}
-            {children}
-          </tbody>
+            {/* =============== TABLE BODY */}
+            <tbody {...tableBodyProps}>
+              {renderTableBodyContent()}
+              {/* extra view with `children` */}
+              {children}
+            </tbody>
 
-          {/* =============== TABLE FOOTER */}
-          {footerView && <tfoot {...tableFooterProps}>{footerView}</tfoot>}
-        </table>
+            {/* =============== TABLE FOOTER */}
+            {footerView && <tfoot {...tableFooterProps}>{footerView}</tfoot>}
+          </table>
+        </StickyOffsetsContext.Provider>
       </div>
       {/* =============== PAGINATION */}
       {pagination && (

--- a/libs/shadcn/src/components/Table/index.tsx
+++ b/libs/shadcn/src/components/Table/index.tsx
@@ -177,7 +177,7 @@ export const Table = <TData,>(props: PropsWithChildren<TableProps<TData>>) => {
     if (loading) {
       if (loadingView) return loadingView;
       return [...Array(loadingRows)].map((_e, i) => (
-        <tr key={i} className="table-row-loading">
+        <tr key={i} className="crudx-table-row-loading">
           {enableCheckbox && <td colSpan={1} />}
           {columns.map((c) => (
             <td
@@ -197,7 +197,7 @@ export const Table = <TData,>(props: PropsWithChildren<TableProps<TData>>) => {
     }
     if (!hasData) {
       return (
-        <tr className="table-row-empty">
+        <tr className="crudx-table-row-empty">
           <td
             colSpan={columnLength}
             className="text-center p-0"
@@ -264,8 +264,8 @@ export const Table = <TData,>(props: PropsWithChildren<TableProps<TData>>) => {
 
   // =============== VIEWS
   return (
-    <div className="table-main-wrapper">
-      {topView && <div className="table-top-container">{topView}</div>}
+    <div className="crudx-table-main-wrapper">
+      {topView && <div className="crudx-table-top-container">{topView}</div>}
       <div
         {...restContainer}
         className={cn('relative w-full overflow-auto', containerClassName)}
@@ -277,8 +277,8 @@ export const Table = <TData,>(props: PropsWithChildren<TableProps<TData>>) => {
         {/* =============== TABLE */}
         <table
           className={cn(
-            'table',
-            `style-${borderStyle}`,
+            'crudx-table',
+            `crudx-style-${borderStyle}`,
             tableVariants({
               striped,
               bordered,
@@ -316,7 +316,7 @@ export const Table = <TData,>(props: PropsWithChildren<TableProps<TData>>) => {
       </div>
       {/* =============== PAGINATION */}
       {pagination && (
-        <div className="table-pagination-wrapper border-t border-[hsl(var(--border))]">
+        <div className="crudx-table-pagination-wrapper border-t border-border">
           {renderPagination?.({
             page,
             total,

--- a/libs/shadcn/src/components/Table/variants.ts
+++ b/libs/shadcn/src/components/Table/variants.ts
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority';
 
 export const tableVariants = cva(
-  'w-full align-middle caption-bottom text-left rtl:text-right text-foreground font-normal text-sm border-separate border-spacing-0',
+  'min-w-full align-middle caption-bottom text-left rtl:text-right text-foreground font-normal text-sm border-separate border-spacing-0',
   {
     variants: {
       borderStyle: {

--- a/libs/shadcn/src/components/Table/variants.ts
+++ b/libs/shadcn/src/components/Table/variants.ts
@@ -9,7 +9,7 @@ export const tableVariants = cva(
         preset: '',
       },
       striped: {
-        true: '[&_tbody_tr:nth-child(even)]:bg-muted/40',
+        true: '[&_tbody_tr:nth-child(even)]:bg-muted/40 [&_tbody_tr:nth-child(even)_[data-sticky]]:bg-[color-mix(in_oklab,hsl(var(--muted))_40%,hsl(var(--background)))]',
         false: '',
       },
       bordered: {

--- a/libs/shadcn/src/components/Table/variants.ts
+++ b/libs/shadcn/src/components/Table/variants.ts
@@ -1,18 +1,24 @@
 import { cva } from 'class-variance-authority';
 
 export const tableVariants = cva(
-  'w-full caption-bottom text-sm border-collapse',
+  'w-full align-middle caption-bottom text-left rtl:text-right text-foreground font-normal text-sm border-separate border-spacing-0',
   {
     variants: {
       borderStyle: {
         default: '',
         preset: '',
       },
-      striped: { true: '[&_tbody_tr:nth-child(even)]:bg-[hsl(var(--muted))]/40', false: '' },
-      bordered: { true: '', false: '' },
+      striped: {
+        true: '[&_tbody_tr:nth-child(even)]:bg-muted/40',
+        false: '',
+      },
+      bordered: {
+        true: '[&_thead_tr>th]:border-e [&_thead_tr>:last-child]:border-e-0 [&_tbody_tr>td]:border-e [&_tbody_tr>:last-child]:border-e-0',
+        false: '',
+      },
       size: {
-        sm: '[&_td]:py-1 [&_td]:px-2 [&_th]:py-1 [&_th]:px-2',
-        md: '[&_td]:py-2.5 [&_td]:px-4 [&_th]:py-2.5 [&_th]:px-4',
+        sm: '[&_th]:h-9 [&_th]:px-3 [&_td]:px-3 [&_td]:py-2',
+        md: '[&_th]:h-10 [&_th]:px-4 [&_td]:px-4 [&_td]:py-3',
       },
     },
     defaultVariants: {

--- a/libs/shadcn/src/components/TableHead/index.tsx
+++ b/libs/shadcn/src/components/TableHead/index.tsx
@@ -154,10 +154,9 @@ export const TableHead = <TData,>(props: TableHeadProps<TData>) => {
     const align = column.alignTitle ?? column.align ?? 'left';
 
     const baseHeadClass = cn(
-      'table-head-row-item',
-      `column-${key}`,
-      'font-semibold whitespace-nowrap',
-      'text-xs',
+      'crudx-table-head-row-item',
+      `crudx-column-${key}`,
+      'relative align-middle font-normal text-accent-foreground [&:has([role=checkbox])]:pe-0',
       alignToClass(align),
       {
         sticky: sticky,
@@ -175,8 +174,11 @@ export const TableHead = <TData,>(props: TableHeadProps<TData>) => {
       }
     );
 
-    const { style: headerStyle, className: headerClassName, ...restHeaderProps } =
-      column.headerColumnProps ?? {};
+    const {
+      style: headerStyle,
+      className: headerClassName,
+      ...restHeaderProps
+    } = column.headerColumnProps ?? {};
 
     return (
       <th
@@ -205,31 +207,32 @@ export const TableHead = <TData,>(props: TableHeadProps<TData>) => {
     <thead
       {...restProps}
       className={cn(
-        'table-head',
+        'crudx-table-head',
         stickyHeader && 'sticky top-0 z-10',
-        'bg-[var(--crudx-head-bg,hsl(var(--background)))]',
         className
       )}
-      style={{
-        backgroundColor,
-        ...style,
-      }}
+      style={style}
     >
       <tr
         {...tableRowProps}
-        className={cn('table-head-row', tableRowProps?.className)}
+        className={cn(
+          'crudx-table-head-row bg-[var(--crudx-head-bg,color-mix(in_oklab,var(--muted)_40%,transparent))]',
+          borderBottom && '[&>th]:border-b',
+          tableRowProps?.className
+        )}
+        style={{ backgroundColor, ...tableRowProps?.style }}
       >
         {enableCheckbox && (
           <th
             className={cn(
-              'table-head-row-item checkbox-column',
-              'w-[44px] text-center p-0',
+              'crudx-table-head-row-item crudx-checkbox-column',
+              'relative w-[44px] text-center align-middle [&:has([role=checkbox])]:pe-0',
               {
-                'sticky border-right': hasCheckBoxSticky,
-                'border-top': borderTop,
-                'border-bottom': borderBottom,
-                'none-border-top': !borderTop,
-                'none-border-bottom': !borderBottom,
+                'sticky crudx-border-right': hasCheckBoxSticky,
+                'crudx-border-top': borderTop,
+                'crudx-border-bottom': borderBottom,
+                'crudx-none-border-top': !borderTop,
+                'crudx-none-border-bottom': !borderBottom,
               }
             )}
             rowSpan={hasGroup ? 2 : undefined}
@@ -264,7 +267,7 @@ export const TableHead = <TData,>(props: TableHeadProps<TData>) => {
         <tr
           {...tableRowProps}
           className={cn(
-            'table-head-row-item grouping-column',
+            'crudx-table-head-row-item crudx-grouping-column',
             tableRowProps?.className
           )}
         >

--- a/libs/shadcn/src/components/TableHead/index.tsx
+++ b/libs/shadcn/src/components/TableHead/index.tsx
@@ -7,6 +7,7 @@ import {
   getColumnPinningStyle,
   getColumnStickyState,
 } from '../../adapters/column-sticky';
+import { useStickyOffsetsContext } from '../../adapters/use-sticky-offsets';
 import { cn } from '../../lib/cn';
 import { Checkbox } from '../../primitives/checkbox';
 
@@ -45,6 +46,7 @@ export const TableHead = <TData,>(props: TableHeadProps<TData>) => {
   const enableCheckbox = checkbox?.enabled ?? false;
   const enableCheckboxSticky = checkbox?.sticky ?? false;
   const hasCheckBoxSticky = enableCheckbox && enableCheckboxSticky;
+  const measuredOffsets = useStickyOffsetsContext();
   const defaultOrderBy = sorting?.defaultOrder;
   const defaultOrderDirection = sorting?.defaultDirection ?? 'asc';
   // restructure header based on its settings
@@ -154,7 +156,12 @@ export const TableHead = <TData,>(props: TableHeadProps<TData>) => {
     const sticky_ = getColumnStickyState(columns, index, hasCheckBoxSticky);
     const pinning = getColumnPinningStyle(columns, index, hasCheckBoxSticky);
     const { hideBorderLeft, hideBorderRight } = sticky_;
-    const { side, offset, isLastLeftPinned, isFirstRightPinned } = pinning;
+    const { side, isLastLeftPinned, isFirstRightPinned } = pinning;
+    const measured = sticky ? measuredOffsets.get(key) : undefined;
+    const leftOffset =
+      side === 'left' ? measured?.left ?? pinning.offset : undefined;
+    const rightOffset =
+      side === 'right' ? measured?.right ?? pinning.offset : undefined;
 
     const align = column.alignTitle ?? column.align ?? 'left';
 
@@ -163,7 +170,8 @@ export const TableHead = <TData,>(props: TableHeadProps<TData>) => {
       `crudx-column-${key}`,
       'relative align-middle font-normal text-accent-foreground [&:has([role=checkbox])]:pe-0',
       alignToClass(align),
-      sticky && 'sticky bg-muted/90 backdrop-blur-xs',
+      sticky &&
+        'sticky bg-[color-mix(in_oklab,hsl(var(--muted))_40%,hsl(var(--background)))]',
       {
         'position-right': sticky && side === 'right',
         'position-left': sticky && side === 'left',
@@ -195,6 +203,7 @@ export const TableHead = <TData,>(props: TableHeadProps<TData>) => {
     return (
       <th
         key={key}
+        data-key={key}
         data-sticky={sticky ? side ?? true : undefined}
         className={cn(baseHeadClass, headerClassName)}
         style={{
@@ -202,8 +211,8 @@ export const TableHead = <TData,>(props: TableHeadProps<TData>) => {
           minWidth: column.minWidth,
           zIndex: sticky ? 4 : undefined,
           verticalAlign: 'middle',
-          ...(sticky && side === 'left' ? { left: offset } : {}),
-          ...(sticky && side === 'right' ? { right: offset } : {}),
+          ...(leftOffset !== undefined ? { left: leftOffset } : {}),
+          ...(rightOffset !== undefined ? { right: rightOffset } : {}),
           ...(boxShadow ? { boxShadow } : {}),
           ...headerStyle,
         }}
@@ -232,7 +241,7 @@ export const TableHead = <TData,>(props: TableHeadProps<TData>) => {
       <tr
         {...tableRowProps}
         className={cn(
-          'crudx-table-head-row bg-[var(--crudx-head-bg,color-mix(in_oklab,var(--muted)_40%,transparent))]',
+          'crudx-table-head-row bg-[var(--crudx-head-bg,color-mix(in_oklab,hsl(var(--muted))_40%,hsl(var(--background))))]',
           borderBottom && '[&>th]:border-b',
           tableRowProps?.className
         )}
@@ -244,7 +253,8 @@ export const TableHead = <TData,>(props: TableHeadProps<TData>) => {
             className={cn(
               'crudx-table-head-row-item crudx-checkbox-column',
               'relative w-[44px] text-center align-middle !px-3',
-              hasCheckBoxSticky && 'sticky bg-muted/90 backdrop-blur-xs',
+              hasCheckBoxSticky &&
+                'sticky bg-[color-mix(in_oklab,hsl(var(--muted))_40%,hsl(var(--background)))]',
               {
                 'border-right': hasCheckBoxSticky,
                 'border-top': borderTop,

--- a/libs/shadcn/src/components/TableHead/index.tsx
+++ b/libs/shadcn/src/components/TableHead/index.tsx
@@ -3,7 +3,10 @@ import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
 import isEmpty from 'lodash/isEmpty';
 
 import { TableColumnType } from '../../@types';
-import { getColumnStickyState } from '../../adapters/column-sticky';
+import {
+  getColumnPinningStyle,
+  getColumnStickyState,
+} from '../../adapters/column-sticky';
 import { cn } from '../../lib/cn';
 import { Checkbox } from '../../primitives/checkbox';
 
@@ -149,7 +152,9 @@ export const TableHead = <TData,>(props: TableHeadProps<TData>) => {
   ) => {
     const { key, sticky } = column;
     const sticky_ = getColumnStickyState(columns, index, hasCheckBoxSticky);
+    const pinning = getColumnPinningStyle(columns, index, hasCheckBoxSticky);
     const { hideBorderLeft, hideBorderRight } = sticky_;
+    const { side, offset, isLastLeftPinned, isFirstRightPinned } = pinning;
 
     const align = column.alignTitle ?? column.align ?? 'left';
 
@@ -158,9 +163,10 @@ export const TableHead = <TData,>(props: TableHeadProps<TData>) => {
       `crudx-column-${key}`,
       'relative align-middle font-normal text-accent-foreground [&:has([role=checkbox])]:pe-0',
       alignToClass(align),
+      sticky && 'sticky bg-muted/90 backdrop-blur-xs',
       {
-        sticky: sticky,
-        'position-right': sticky,
+        'position-right': sticky && side === 'right',
+        'position-left': sticky && side === 'left',
         'table-head-group': groupType === 'group',
         'table-head-group-item': groupType === 'item',
         'border-left': sticky,
@@ -180,15 +186,25 @@ export const TableHead = <TData,>(props: TableHeadProps<TData>) => {
       ...restHeaderProps
     } = column.headerColumnProps ?? {};
 
+    const boxShadow = isLastLeftPinned
+      ? '-4px 0 4px -4px rgb(0 0 0 / 0.15) inset'
+      : isFirstRightPinned
+      ? '4px 0 4px -4px rgb(0 0 0 / 0.15) inset'
+      : undefined;
+
     return (
       <th
         key={key}
+        data-sticky={sticky ? side ?? true : undefined}
         className={cn(baseHeadClass, headerClassName)}
         style={{
           width: column.width,
           minWidth: column.minWidth,
           zIndex: sticky ? 4 : undefined,
           verticalAlign: 'middle',
+          ...(sticky && side === 'left' ? { left: offset } : {}),
+          ...(sticky && side === 'right' ? { right: offset } : {}),
+          ...(boxShadow ? { boxShadow } : {}),
           ...headerStyle,
         }}
         colSpan={colSpan}
@@ -224,19 +240,24 @@ export const TableHead = <TData,>(props: TableHeadProps<TData>) => {
       >
         {enableCheckbox && (
           <th
+            data-sticky={hasCheckBoxSticky ? 'left' : undefined}
             className={cn(
               'crudx-table-head-row-item crudx-checkbox-column',
-              'relative w-[44px] text-center align-middle [&:has([role=checkbox])]:pe-0',
+              'relative w-[44px] text-center align-middle !px-3',
+              hasCheckBoxSticky && 'sticky bg-muted/90 backdrop-blur-xs',
               {
-                'sticky crudx-border-right': hasCheckBoxSticky,
-                'crudx-border-top': borderTop,
-                'crudx-border-bottom': borderBottom,
-                'crudx-none-border-top': !borderTop,
-                'crudx-none-border-bottom': !borderBottom,
+                'border-right': hasCheckBoxSticky,
+                'border-top': borderTop,
+                'border-bottom': borderBottom,
+                'none-border-top': !borderTop,
+                'none-border-bottom': !borderBottom,
               }
             )}
             rowSpan={hasGroup ? 2 : undefined}
-            style={{ verticalAlign: 'middle' }}
+            style={{
+              verticalAlign: 'middle',
+              ...(hasCheckBoxSticky ? { left: 0, zIndex: 4 } : {}),
+            }}
           >
             <Checkbox
               aria-label="Select all"

--- a/libs/shadcn/src/components/TableRow/index.tsx
+++ b/libs/shadcn/src/components/TableRow/index.tsx
@@ -2,7 +2,10 @@ import React, { useEffect, useState } from 'react';
 import * as Collapsible from '@radix-ui/react-collapsible';
 
 import { InferDataColumnType, TableColumnType } from '../../@types';
-import { getColumnStickyState } from '../../adapters/column-sticky';
+import {
+  getColumnPinningStyle,
+  getColumnStickyState,
+} from '../../adapters/column-sticky';
 import { cn } from '../../lib/cn';
 import { Checkbox } from '../../primitives/checkbox';
 
@@ -90,7 +93,7 @@ export const TableRow = <TData,>(props: TableRowProps<TData>) => {
         {...restProps}
         data-state={checked ? 'selected' : undefined}
         className={cn(
-          'crudx-table-row border-b border-border [&:not(:last-child)>td]:border-b hover:bg-muted/40 data-[state=selected]:bg-muted/50 [&_>:first-child]:relative',
+          'crudx-table-row [&:not(:last-child)>td]:border-b [&_>td]:border-border hover:bg-muted/40 data-[state=selected]:bg-muted/50',
           clickable && 'cursor-pointer',
           className
         )}
@@ -99,13 +102,18 @@ export const TableRow = <TData,>(props: TableRowProps<TData>) => {
         {/* CHECKBOX */}
         {enableCheckbox && (
           <td
+            data-sticky={hasCheckBoxSticky ? 'left' : undefined}
             className={cn(
-              'crudx-table-row-item crudx-checkbox-column text-center align-middle [&:has([role=checkbox])]:pe-0',
+              'crudx-table-row-item crudx-checkbox-column text-center align-middle !px-3',
+              hasCheckBoxSticky && 'sticky bg-background/90 backdrop-blur-xs',
               {
-                'sticky border-right': hasCheckBoxSticky,
+                'border-right': hasCheckBoxSticky,
               }
             )}
-            style={{ verticalAlign: valignToStyle(valignCheckbox) }}
+            style={{
+              verticalAlign: valignToStyle(valignCheckbox),
+              ...(hasCheckBoxSticky ? { left: 0, zIndex: 3 } : {}),
+            }}
           >
             <Checkbox
               checked={checked}
@@ -122,6 +130,8 @@ export const TableRow = <TData,>(props: TableRowProps<TData>) => {
             index,
             hasCheckBoxSticky
           );
+          const { side, offset, isLastLeftPinned, isFirstRightPinned } =
+            getColumnPinningStyle(columns, index, hasCheckBoxSticky);
 
           const result = dataIndex ? (data as any)[dataIndex] : data;
           const finalClassName =
@@ -135,16 +145,25 @@ export const TableRow = <TData,>(props: TableRowProps<TData>) => {
             ...restCellProps
           } = column.dataColumnProps ?? {};
 
+          const boxShadow = isLastLeftPinned
+            ? '-4px 0 4px -4px rgb(0 0 0 / 0.15) inset'
+            : isFirstRightPinned
+            ? '4px 0 4px -4px rgb(0 0 0 / 0.15) inset'
+            : undefined;
+
           return (
             <td
               key={`${key}-${index}`}
+              data-sticky={sticky ? side ?? true : undefined}
               className={cn(
                 'crudx-table-row-item',
                 `crudx-column-${key}`,
                 'align-middle [&:has([role=checkbox])]:pe-0',
                 alignToClass(column.align ?? 'left'),
+                sticky && 'sticky bg-background/90 backdrop-blur-xs',
                 {
-                  'sticky position-right': sticky,
+                  'position-right': sticky && side === 'right',
+                  'position-left': sticky && side === 'left',
                   'border-left': sticky,
                   'border-right': sticky,
                   'none-border-left': hideBorderLeft,
@@ -157,6 +176,10 @@ export const TableRow = <TData,>(props: TableRowProps<TData>) => {
                 width: column.width,
                 minWidth: column.minWidth,
                 verticalAlign: valignToStyle(column.valign ?? valign),
+                ...(sticky ? { zIndex: 3 } : {}),
+                ...(sticky && side === 'left' ? { left: offset } : {}),
+                ...(sticky && side === 'right' ? { right: offset } : {}),
+                ...(boxShadow ? { boxShadow } : {}),
                 ...cellStyle,
               }}
               {...restCellProps}

--- a/libs/shadcn/src/components/TableRow/index.tsx
+++ b/libs/shadcn/src/components/TableRow/index.tsx
@@ -6,6 +6,7 @@ import {
   getColumnPinningStyle,
   getColumnStickyState,
 } from '../../adapters/column-sticky';
+import { useStickyOffsetsContext } from '../../adapters/use-sticky-offsets';
 import { cn } from '../../lib/cn';
 import { Checkbox } from '../../primitives/checkbox';
 
@@ -47,6 +48,7 @@ export const TableRow = <TData,>(props: TableRowProps<TData>) => {
   const enableCheckbox = checkbox?.enabled ?? false;
   const enableCheckboxSticky = checkbox?.sticky ?? false;
   const hasCheckBoxSticky = enableCheckbox && enableCheckboxSticky;
+  const measuredOffsets = useStickyOffsetsContext();
 
   // =============== STATE
   const [expanded, setExpanded] = useState(false);
@@ -93,7 +95,7 @@ export const TableRow = <TData,>(props: TableRowProps<TData>) => {
         {...restProps}
         data-state={checked ? 'selected' : undefined}
         className={cn(
-          'crudx-table-row [&:not(:last-child)>td]:border-b [&_>td]:border-border hover:bg-muted/40 data-[state=selected]:bg-muted/50',
+          'group crudx-table-row [&:not(:last-child)>td]:border-b [&_>td]:border-border hover:bg-muted/40 data-[state=selected]:bg-muted/50',
           clickable && 'cursor-pointer',
           className
         )}
@@ -105,7 +107,8 @@ export const TableRow = <TData,>(props: TableRowProps<TData>) => {
             data-sticky={hasCheckBoxSticky ? 'left' : undefined}
             className={cn(
               'crudx-table-row-item crudx-checkbox-column text-center align-middle !px-3',
-              hasCheckBoxSticky && 'sticky bg-background/90 backdrop-blur-xs',
+              hasCheckBoxSticky &&
+                'sticky bg-background group-hover:bg-[color-mix(in_oklab,hsl(var(--muted))_40%,hsl(var(--background)))] group-data-[state=selected]:bg-[color-mix(in_oklab,hsl(var(--muted))_50%,hsl(var(--background)))]',
               {
                 'border-right': hasCheckBoxSticky,
               }
@@ -130,8 +133,17 @@ export const TableRow = <TData,>(props: TableRowProps<TData>) => {
             index,
             hasCheckBoxSticky
           );
-          const { side, offset, isLastLeftPinned, isFirstRightPinned } =
-            getColumnPinningStyle(columns, index, hasCheckBoxSticky);
+          const pinning = getColumnPinningStyle(
+            columns,
+            index,
+            hasCheckBoxSticky
+          );
+          const { side, isLastLeftPinned, isFirstRightPinned } = pinning;
+          const measured = sticky ? measuredOffsets.get(key) : undefined;
+          const leftOffset =
+            side === 'left' ? measured?.left ?? pinning.offset : undefined;
+          const rightOffset =
+            side === 'right' ? measured?.right ?? pinning.offset : undefined;
 
           const result = dataIndex ? (data as any)[dataIndex] : data;
           const finalClassName =
@@ -160,7 +172,8 @@ export const TableRow = <TData,>(props: TableRowProps<TData>) => {
                 `crudx-column-${key}`,
                 'align-middle [&:has([role=checkbox])]:pe-0',
                 alignToClass(column.align ?? 'left'),
-                sticky && 'sticky bg-background/90 backdrop-blur-xs',
+                sticky &&
+                  'sticky bg-background group-hover:bg-[color-mix(in_oklab,hsl(var(--muted))_40%,hsl(var(--background)))] group-data-[state=selected]:bg-[color-mix(in_oklab,hsl(var(--muted))_50%,hsl(var(--background)))]',
                 {
                   'position-right': sticky && side === 'right',
                   'position-left': sticky && side === 'left',
@@ -177,8 +190,8 @@ export const TableRow = <TData,>(props: TableRowProps<TData>) => {
                 minWidth: column.minWidth,
                 verticalAlign: valignToStyle(column.valign ?? valign),
                 ...(sticky ? { zIndex: 3 } : {}),
-                ...(sticky && side === 'left' ? { left: offset } : {}),
-                ...(sticky && side === 'right' ? { right: offset } : {}),
+                ...(leftOffset !== undefined ? { left: leftOffset } : {}),
+                ...(rightOffset !== undefined ? { right: rightOffset } : {}),
                 ...(boxShadow ? { boxShadow } : {}),
                 ...cellStyle,
               }}

--- a/libs/shadcn/src/components/TableRow/index.tsx
+++ b/libs/shadcn/src/components/TableRow/index.tsx
@@ -90,10 +90,8 @@ export const TableRow = <TData,>(props: TableRowProps<TData>) => {
         {...restProps}
         data-state={checked ? 'selected' : undefined}
         className={cn(
-          'table-row border-b border-[hsl(var(--border))] transition-colors',
+          'crudx-table-row border-b border-border [&:not(:last-child)>td]:border-b hover:bg-muted/40 data-[state=selected]:bg-muted/50 [&_>:first-child]:relative',
           clickable && 'cursor-pointer',
-          checked && 'bg-[hsl(var(--muted))]/50',
-          'hover:bg-[hsl(var(--muted))]/30',
           className
         )}
         onClick={onClickRow}
@@ -101,9 +99,12 @@ export const TableRow = <TData,>(props: TableRowProps<TData>) => {
         {/* CHECKBOX */}
         {enableCheckbox && (
           <td
-            className={cn('table-row-item checkbox-column p-0 text-center', {
-              'sticky border-right': hasCheckBoxSticky,
-            })}
+            className={cn(
+              'crudx-table-row-item crudx-checkbox-column text-center align-middle [&:has([role=checkbox])]:pe-0',
+              {
+                'sticky border-right': hasCheckBoxSticky,
+              }
+            )}
             style={{ verticalAlign: valignToStyle(valignCheckbox) }}
           >
             <Checkbox
@@ -138,8 +139,9 @@ export const TableRow = <TData,>(props: TableRowProps<TData>) => {
             <td
               key={`${key}-${index}`}
               className={cn(
-                'table-row-item',
-                `column-${key}`,
+                'crudx-table-row-item',
+                `crudx-column-${key}`,
+                'align-middle [&:has([role=checkbox])]:pe-0',
                 alignToClass(column.align ?? 'left'),
                 {
                   'sticky position-right': sticky,
@@ -165,7 +167,7 @@ export const TableRow = <TData,>(props: TableRowProps<TData>) => {
         })}
       </tr>
       {expandable && (
-        <tr className="table-row-expand">
+        <tr className="crudx-table-row-expand">
           <td
             colSpan={columns.length + (enableCheckbox ? 1 : 0)}
             style={{ padding: 0 }}

--- a/libs/shadcn/src/views/CrudContentHeaderView/hooks/useHeaderInfo.tsx
+++ b/libs/shadcn/src/views/CrudContentHeaderView/hooks/useHeaderInfo.tsx
@@ -63,7 +63,7 @@ export const useHeaderInfos = (
               <p
                 {...restProps}
                 className={cn(
-                  'crud-content-header-total-count text-sm text-[hsl(var(--muted-foreground))]',
+                  'crudx-content-header-total-count text-sm text-[hsl(var(--muted-foreground))]',
                   className
                 )}
               >
@@ -85,7 +85,7 @@ export const useHeaderInfos = (
             return (
               <TableSelectedBulkOptions
                 size={headerActionSize}
-                className="crud-content-header-bulk-node"
+                className="crudx-content-header-bulk-node"
                 text={f?.text}
                 items={headerBulkOptions ?? f.items}
                 total={totalSelected}

--- a/libs/shadcn/src/views/CrudContentHeaderView/index.tsx
+++ b/libs/shadcn/src/views/CrudContentHeaderView/index.tsx
@@ -40,7 +40,7 @@ export const CrudContentHeaderView = (props: CrudContentHeaderViewProps) => {
     const view = typeof viewNode === 'function' ? viewNode() : viewNode;
     if (!view) return null;
     return (
-      <div className="crud-content-header-wrapper">
+      <div className="crudx-content-header-wrapper">
         {view}
         <TabView
           {...headerTabsProps}
@@ -56,11 +56,11 @@ export const CrudContentHeaderView = (props: CrudContentHeaderViewProps) => {
     return null;
   }
   return (
-    <div className="crud-content-header-wrapper">
+    <div className="crudx-content-header-wrapper">
       {(hasInfos || hasActions) && (
-        <div className="crud-content-header-primary flex flex-wrap items-center gap-2 px-4 py-3 border-b border-[hsl(var(--border))]">
+        <div className="crudx-content-header-primary flex flex-wrap items-center gap-2 px-4 py-3 border-b border-[hsl(var(--border))]">
           {headerInfoViews.length > 0 && (
-            <div className="crud-content-header-infos">
+            <div className="crudx-content-header-infos">
               <RenderNodeView
                 direction="row"
                 alignItems="center"
@@ -74,7 +74,7 @@ export const CrudContentHeaderView = (props: CrudContentHeaderViewProps) => {
           )}
 
           {headerActionViews.length > 0 && (
-            <div className="crud-content-header-actions ml-auto">
+            <div className="crudx-content-header-actions ml-auto">
               <RenderNodeView
                 direction="row"
                 alignItems="center"
@@ -90,7 +90,7 @@ export const CrudContentHeaderView = (props: CrudContentHeaderViewProps) => {
       )}
       {/* ====== EXPAND CONTENT */}
       {expanded && (
-        <div className="crud-content-header-expanded-content border-b border-[hsl(var(--border))]">
+        <div className="crudx-content-header-expanded-content border-b border-[hsl(var(--border))]">
           {typeof expandNode === 'function' ? expandNode() : expandNode}
         </div>
       )}
@@ -100,7 +100,7 @@ export const CrudContentHeaderView = (props: CrudContentHeaderViewProps) => {
         <TabView
           {...headerTabsProps}
           className={cn(
-            'crud-content-header-tabview',
+            'crudx-content-header-tabview',
             headerTabsProps?.className
           )}
           value={headerTabState}
@@ -111,7 +111,7 @@ export const CrudContentHeaderView = (props: CrudContentHeaderViewProps) => {
 
       {/* ====== EXTRA CONTENT */}
       {extraNode && (
-        <div className="crud-content-header-extra-content border-t border-[hsl(var(--border))]">
+        <div className="crudx-content-header-extra-content border-t border-[hsl(var(--border))]">
           {typeof extraNode === 'function' ? extraNode() : extraNode}
         </div>
       )}

--- a/libs/shadcn/src/views/CrudContentView/index.tsx
+++ b/libs/shadcn/src/views/CrudContentView/index.tsx
@@ -171,7 +171,7 @@ export const CrudContentView = <TData = any,>(
     }
 
     return (
-      <div className="crud-content-paginate-button flex flex-wrap items-center justify-center gap-2">
+      <div className="crudx-content-paginate-button flex flex-wrap items-center justify-center gap-2">
         <Button
           size={headerActionSize}
           variant="outline"
@@ -195,7 +195,7 @@ export const CrudContentView = <TData = any,>(
   const renderContentView = () => {
     if (loading) {
       return (
-        <div className="crud-content-data-loading">
+        <div className="crudx-content-data-loading">
           {loadingView ?? (
             <div className="py-10 text-center">
               <Loader2 className="inline-block h-10 w-10 animate-spin text-[hsl(var(--muted-foreground))]" />
@@ -207,7 +207,7 @@ export const CrudContentView = <TData = any,>(
 
     if (!hasData) {
       return (
-        <div className="crud-content-data-empty">
+        <div className="crudx-content-data-empty">
           {emptyView ?? (
             <p className="py-12 text-center text-[hsl(var(--muted-foreground))]">
               {noDataView ?? 'No Data'}
@@ -222,7 +222,7 @@ export const CrudContentView = <TData = any,>(
     }
 
     return (
-      <div className="crud-content-data-items">
+      <div className="crudx-content-data-items">
         {data.map((record, i) => {
           const checkIndex = extractCheckedValue(record);
           const isChecked = checkIndex
@@ -274,7 +274,9 @@ export const CrudContentView = <TData = any,>(
 
   // =============== VIEW
   return (
-    <div className={cn('crud-content-wrapper', !unstyled && 'mt-6', className)}>
+    <div
+      className={cn('crudx-content-wrapper', !unstyled && 'mt-6', className)}
+    >
       {/* ==== HEADER */}
       <CrudContentHeaderView
         text={text as any}
@@ -311,15 +313,13 @@ export const CrudContentView = <TData = any,>(
       />
 
       {/* ==== CONTENT */}
-      <div
-        className={cn('crud-content-data-wrapper', !unstyled && 'py-4')}
-      >
+      <div className={cn('crudx-content-data-wrapper', !unstyled && 'py-4')}>
         {renderContentView()}
       </div>
 
       {/* ==== PAGINATION */}
       <div
-        className={cn('crud-content-pagination-wrapper', !unstyled && 'p-2')}
+        className={cn('crudx-content-pagination-wrapper', !unstyled && 'p-2')}
       >
         {renderPaginationView()}
       </div>

--- a/libs/shadcn/src/views/CrudFilterView/index.tsx
+++ b/libs/shadcn/src/views/CrudFilterView/index.tsx
@@ -25,7 +25,7 @@ export const CrudFilterView = memo((props: CrudFilterViewProps) => {
   return (
     <div
       className={cn(
-        'crud-filter-wrapper',
+        'crudx-filter-wrapper',
         !unstyled &&
           'rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-4 mb-6',
         className
@@ -35,7 +35,7 @@ export const CrudFilterView = memo((props: CrudFilterViewProps) => {
       {title && (
         <div
           className={cn(
-            'crud-filter-title text-base font-bold',
+            'crudx-filter-title text-base font-bold',
             !unstyled && 'mb-2'
           )}
         >
@@ -47,7 +47,7 @@ export const CrudFilterView = memo((props: CrudFilterViewProps) => {
       {!!children && (
         <div
           className={cn(
-            'crud-filter-content',
+            'crudx-filter-content',
             !unstyled && hasActions && 'mb-2'
           )}
         >
@@ -57,10 +57,10 @@ export const CrudFilterView = memo((props: CrudFilterViewProps) => {
 
       {/* ---- ACTIONS */}
       {typeof actions === 'function' && (
-        <div className="crud-filter-actions">{actions()}</div>
+        <div className="crudx-filter-actions">{actions()}</div>
       )}
       {typeof actions === 'object' && (actions as any[]).length > 0 && (
-        <div className="crud-filter-actions">
+        <div className="crudx-filter-actions">
           <RenderFlexView items={[actions as any]} />
         </div>
       )}

--- a/libs/shadcn/src/views/CrudPageHeaderView/index.tsx
+++ b/libs/shadcn/src/views/CrudPageHeaderView/index.tsx
@@ -41,7 +41,7 @@ export const CrudPageHeaderView = memo((props: CrudPageHeaderViewProps) => {
     <div
       {...wrapperProps}
       className={cn(
-        'crud-page-header-wrapper',
+        'crudx-page-header-wrapper',
         !unstyled && 'mb-6',
         className
       )}
@@ -49,21 +49,21 @@ export const CrudPageHeaderView = memo((props: CrudPageHeaderViewProps) => {
       {/* ---- BREADCRUMBS */}
       {hasBreadcrumbs && (
         <BreadcrumbView
-          className={cn('crud-page-header-breadcrumbs', !unstyled && 'mb-2')}
+          className={cn('crudx-page-header-breadcrumbs', !unstyled && 'mb-2')}
           items={items}
           {...breadcrumbProps}
         />
       )}
 
-      <div className="crud-page-header-content flex items-center">
+      <div className="crudx-page-header-content flex items-center">
         {/* ---- TITLE VIEW */}
-        <div className="crud-page-header-title flex items-center gap-2">
+        <div className="crudx-page-header-title flex items-center gap-2">
           {/* ---- BACK BUTTON */}
           {backPath && (
             <NextLink
               {...backPathProps}
               className={cn(
-                'crud-page-header-title-back inline-flex items-center',
+                'crudx-page-header-title-back inline-flex items-center',
                 backPathProps?.className
               )}
               href={backPath}
@@ -77,7 +77,7 @@ export const CrudPageHeaderView = memo((props: CrudPageHeaderViewProps) => {
             <h1
               {...titleProps}
               className={cn(
-                'crud-page-header-title-text text-2xl font-semibold leading-none tracking-tight',
+                'crudx-page-header-title-text text-2xl font-semibold leading-none tracking-tight',
                 titleProps?.className
               )}
             >
@@ -88,7 +88,7 @@ export const CrudPageHeaderView = memo((props: CrudPageHeaderViewProps) => {
 
         {/* ---- ACTIONS VIEWS */}
         {hasActions && (
-          <div className="crud-page-header-actions ml-auto">
+          <div className="crudx-page-header-actions ml-auto">
             <RenderNodeView direction="row" gap={2} items={actions} />
           </div>
         )}

--- a/libs/shadcn/src/views/CrudPanelView/hooks/useCrudTableItemAction/index.tsx
+++ b/libs/shadcn/src/views/CrudPanelView/hooks/useCrudTableItemAction/index.tsx
@@ -5,13 +5,7 @@ import {
   CrudCommonActions,
   CrudSchemataTypes,
 } from '@crudx/core';
-import {
-  ChevronDownCircle,
-  Download,
-  Eye,
-  Pencil,
-  Trash2,
-} from 'lucide-react';
+import { ChevronDownCircle, Download, Eye, Pencil, Trash2 } from 'lucide-react';
 import includes from 'lodash/includes';
 import isNil from 'lodash/isNil';
 import startCase from 'lodash/startCase';
@@ -19,7 +13,10 @@ import startCase from 'lodash/startCase';
 import { cn } from '../../../../lib/cn';
 import { Button } from '../../../../primitives/button';
 import { DropdownMenuItem } from '../../../../primitives/dropdown-menu';
-import { TooltipView, TooltipViewProps } from '../../../../components/TooltipView';
+import {
+  TooltipView,
+  TooltipViewProps,
+} from '../../../../components/TooltipView';
 
 import {
   CrudTableItemActionEnabler,
@@ -116,7 +113,7 @@ export const useCrudTableItemAction = <T extends CrudSchemataTypes = any>(
       if (nodeType === 'menu') {
         if (url) {
           return (
-            <DropdownMenuItem asChild className="crud-item-action-link">
+            <DropdownMenuItem asChild className="crudx-item-action-link">
               <Link href={url} {...openNewTab}>
                 {node}
               </Link>
@@ -124,14 +121,14 @@ export const useCrudTableItemAction = <T extends CrudSchemataTypes = any>(
           );
         }
         return (
-          <DropdownMenuItem className="crud-item-action-link">
+          <DropdownMenuItem className="crudx-item-action-link">
             {node}
           </DropdownMenuItem>
         );
       }
       if (!url) return node;
       return (
-        <Link className="crud-item-action-link" href={url} {...openNewTab}>
+        <Link className="crudx-item-action-link" href={url} {...openNewTab}>
           {node}
         </Link>
       );
@@ -166,7 +163,7 @@ export const useCrudTableItemAction = <T extends CrudSchemataTypes = any>(
           return renderLink(
             <span
               className={cn(
-                'crud-item-action-menu-type flex items-center w-full',
+                'crudx-item-action-menu-type flex items-center w-full',
                 type
               )}
             >
@@ -192,7 +189,7 @@ export const useCrudTableItemAction = <T extends CrudSchemataTypes = any>(
         const isButton = nodeType === 'button';
         const buttonNode = (
           <Button
-            className={cn('crud-item-action-button-type', type)}
+            className={cn('crudx-item-action-button-type', type)}
             size={isButton ? size : 'icon'}
             variant={isButton ? 'outline' : 'ghost'}
             aria-label={type}

--- a/libs/shadcn/src/views/CrudPanelView/index.tsx
+++ b/libs/shadcn/src/views/CrudPanelView/index.tsx
@@ -45,11 +45,7 @@ function CrudPanelViewComponent<
   // =============== VIEWS
   return (
     <div
-      className={cn(
-        'crud-panel-wrapper',
-        !unstyled && 'space-y-0',
-        className
-      )}
+      className={cn('crudx-panel-wrapper', !unstyled && 'space-y-0', className)}
     >
       {renderAlert?.()}
       {enablePageHeader && renderPageHeader?.()}

--- a/libs/shadcn/src/views/CrudTableView/index.tsx
+++ b/libs/shadcn/src/views/CrudTableView/index.tsx
@@ -90,7 +90,7 @@ export const CrudTableView = <TData = any,>(
     if (includes(['pagination'], paginateType)) return null;
 
     return (
-      <div className="crud-table-paginate-button flex flex-wrap items-center justify-end gap-2">
+      <div className="crudx-table-paginate-button flex flex-wrap items-center justify-end gap-2">
         <Button
           size={size as any}
           variant="outline"
@@ -114,7 +114,7 @@ export const CrudTableView = <TData = any,>(
   return (
     <div
       className={cn(
-        'crud-table-wrapper',
+        'crudx-table-wrapper',
         !unstyled &&
           'rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--card))] mt-6',
         className


### PR DESCRIPTION
# Summary of the changes

<!-- highlight the main point of the proposed changes -->

1. Restyle `@crudx/shadcn` Table
2. Prefix the developer-targeting CSS class hooks with `crudx-` so consumers can target them without colliding with Tailwind utilities
3. Make sticky columns actually stick (action column + checkbox column).
4. Enable horizontal scroll by changing the table base from `w-full` to `min-w-full`
5. Fix sticky cell visual issues: transparent background 
6. Add a live "Table, sticky columns" demo

---

## Reference to the cards / issues / tickets

---

## Screenshots / Videos / Examples

<!-- insert app screenshots here -->

To verify locally:

1. Visit `/components-shadcn`.
2. Scroll to the **"Table — sticky columns"** section between `Table` and `TableHead`
3. Scroll the table horizontally, the checkbox column stays anchored on the left edge, the action column stays anchored on the right edge, and inset box-shadows mark the sticky boundaries. No bg bleed-through, no border drift

---

Put an `x` in all the boxes that apply

## Checklist

- [x] I have performed a self-review of my own code, including:
  - Code is consistent with the project's style guidelines.
  - Code is well-organized and easy to read.
  - Code is adequately commented on where necessary.
- [x] I did lint my code locally prior to pushing and resolved any issues found.
- [x] The pull request fully complies with the project requirement
- [x] The pull request does not introduce any security vulnerabilities.
- [x] The pull request does not introduce new code smells, such as duplicate code or unnecessary complexity.
- [x] The pull request has been tested locally or in a staging environment and is working with no bugs

